### PR TITLE
Generate ARM binaries from Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ $(if $(and $(filter-out darwin_arm,$(1)_$(2)), $(filter-out windows_arm,$(1)_$(2
 endef
 
 cross: *.go VERSION
-	$(foreach GOARCH,$(GOARCHS),$(foreach GOOS,$(GOOSES), $(call buildpretty,$(GOOS),$(GOARCH))))
+	$(foreach GOARCH,$(GOARCHS),$(foreach GOOS,$(GOOSES),$(call buildpretty,$(GOOS),$(GOARCH))))
 
 define buildrelease
 $(if $(and $(filter-out darwin_arm,$(1)_$(2)), $(filter-out windows_arm,$(1)_$(2))), \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CTIMEVAR=-X $(PKG)/version.GITCOMMIT=$(GITCOMMIT) -X $(PKG)/version.VERSION=$(VE
 GO_LDFLAGS=-ldflags "-w $(CTIMEVAR)"
 GO_LDFLAGS_STATIC=-ldflags "-w $(CTIMEVAR) -extldflags -static"
 GOOSES = darwin freebsd linux windows
-GOARCHS = amd64 386
+GOARCHS = amd64 386 arm
 
 run:
 	go run ./main.go
@@ -29,16 +29,20 @@ test:
 	go test ./...
 
 define buildpretty
-mkdir -p ${PREFIX}/cross/$(1)/$(2);
-GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -o ${PREFIX}/cross/$(1)/$(2)/dry -a -tags "static_build netgo" -installsuffix netgo ${GO_LDFLAGS_STATIC} .;
+$(if $(and $(filter-out darwin_arm,$(1)_$(2)), $(filter-out windows_arm,$(1)_$(2))), \
+	mkdir -p ${PREFIX}/cross/$(1)/$(2);
+	GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -o ${PREFIX}/cross/$(1)/$(2)/dry -a -tags "static_build netgo" -installsuffix netgo ${GO_LDFLAGS_STATIC} .;
+)
 endef
 
 cross: *.go VERSION
-	$(foreach GOARCH,$(GOARCHS),$(foreach GOOS,$(GOOSES),$(call buildpretty,$(GOOS),$(GOARCH))))
+	$(foreach GOARCH,$(GOARCHS),$(foreach GOOS,$(GOOSES), $(call buildpretty,$(GOOS),$(GOARCH))))
 
 define buildrelease
-mkdir -p ${PREFIX}/cross/$(1)/$(2);
-GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -o ${PREFIX}/cross/dry-$(1)-$(2) -a -tags "static_build netgo" -installsuffix netgo ${GO_LDFLAGS_STATIC} .;
+$(if $(and $(filter-out darwin_arm,$(1)_$(2)), $(filter-out windows_arm,$(1)_$(2))), \
+	mkdir -p ${PREFIX}/cross/$(1)/$(2);
+	GOOS=$(1) GOARCH=$(2) CGO_ENABLED=0 go build -o ${PREFIX}/cross/dry-$(1)-$(2) -a -tags "static_build netgo" -installsuffix netgo ${GO_LDFLAGS_STATIC} .;
+)
 endef
 
 release: *.go VERSION


### PR DESCRIPTION
This PR allows dry to compile ARM binaries for FreeBSD & Linux. 
I have tested both `cross` and `release` targets.