### PR TITLE
fix syntax error such that dry is compilable for go1.3.3 linux/arm

### DIFF
--- a/app/dry.go
+++ b/app/dry.go
@@ -368,13 +368,13 @@ func (d *Dry) SortNetworks() {
 func (d *Dry) startDry() {
 	go func() {
 		//The event is not relevant, dry must refresh
-		for range d.dockerEvents {
+		for _ = range d.dockerEvents {
 			d.Refresh()
 		}
 	}()
 
 	go func() {
-		for range time.Tick(TimeBetweenRefresh) {
+		for _ = range time.Tick(TimeBetweenRefresh) {
 			d.tryRefresh()
 		}
 	}()


### PR DESCRIPTION
Resolves the following syntax errors on make install. 

$ make install
go install github.com/moncho/dry
Press ENTER or type command to continue

# github.com/moncho/dry/app
app/dry.go:371: syntax error: unexpected range, expecting {
app/dry.go:377: syntax error: unexpected range, expecting {
Makefile:26: recipe for target 'install' failed
make: *** [install] Error 2