### PR TITLE
Prepare for release v0.6-alpha.2

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,10 +1,10 @@
 {
 	"ImportPath": "github.com/moncho/dry",
-	"GoVersion": "go1.6",
+	"GoVersion": "go1.7",
 	"GodepVersion": "v74",
 	"Packages": [
-          "github.com/moncho/dry"
-   ],
+		"github.com/moncho/dry"
+	],
 	"Deps": [
 		{
 			"ImportPath": "github.com/Microsoft/go-winio",
@@ -160,6 +160,11 @@
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/user",
 			"Comment": "v0.1.0-13-gc6db82f",
 			"Rev": "c6db82f9219b2ea4c98f80560205ed6c65aeea19"
+		},
+		{
+			"ImportPath": "github.com/pkg/errors",
+			"Comment": "v0.7.0-1-g494e70f",
+			"Rev": "494e70f7620561491c2ca11e185bbef4b70060da"
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",

--- a/app/container_events.go
+++ b/app/container_events.go
@@ -213,10 +213,12 @@ loop:
 			}
 		case s := <-stats:
 			{
+				//Magic number 3 is the separations between container info
+				//and stats
 				mutex.Lock()
 				screen.RenderBufferer(
 					appui.NewDockerStatsBufferer(
-						s, 0, infoLines+3, screen.Height, screen.Width)...)
+						s, 0, infoLines+3, screen.Height-infoLines-3, screen.Width)...)
 				screen.Flush()
 				mutex.Unlock()
 			}
@@ -244,7 +246,7 @@ func showContainerOptions(h containersScreenEventHandler, dry *Dry, screen *ui.S
 		screen.Cursor.Reset()
 
 		info, infoLines := appui.NewContainerInfo(container)
-		screen.RenderLineWithBackGround(0, screen.Height-1, commandsMenuBar, ui.MenuBarBackgroundColor)
+		screen.RenderLineWithBackGround(0, screen.Height-1, commandsMenuBar, appui.DryTheme.Footer)
 		screen.Render(1, info)
 		l := appui.NewContainerCommands(container,
 			0,

--- a/app/container_events.go
+++ b/app/container_events.go
@@ -161,6 +161,10 @@ func (h containersScreenEventHandler) handleCommand(command commandToExecute) {
 		dry.Inspect(id)
 		focus = false
 		go appui.Less(renderDry(dry), screen, h.keyboardQueueForView, h.closeView)
+	case docker.HISTORY:
+		dry.History(command.container.ImageID)
+		focus = false
+		go appui.Less(renderDry(dry), screen, h.keyboardQueueForView, h.closeView)
 	}
 	if focus {
 		h.closeView <- struct{}{}

--- a/app/dry.go
+++ b/app/dry.go
@@ -227,6 +227,9 @@ func (d *Dry) Refresh() {
 }
 
 func (d *Dry) doRefresh() {
+	d.state.mutex.Lock()
+	defer d.state.mutex.Unlock()
+	d.state.changed = true
 	var err error
 	switch d.state.viewMode {
 	case Main:
@@ -244,9 +247,6 @@ func (d *Dry) doRefresh() {
 	if err != nil {
 		d.appmessage("There was an error refreshing: " + err.Error())
 	}
-	d.state.mutex.Lock()
-	defer d.state.mutex.Unlock()
-	d.state.changed = true
 }
 
 //RemoveAllStoppedContainers removes all stopped containers

--- a/app/dry.go
+++ b/app/dry.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	//TimeBetweenRefresh defines the time that has to pass between dry refreshes
-	TimeBetweenRefresh = 10 * time.Second
+	TimeBetweenRefresh = 30 * time.Second
 )
 
 // state tracks dry state
@@ -203,6 +203,11 @@ func (d *Dry) Logs(id string) (io.ReadCloser, error) {
 	return d.dockerDaemon.Logs(id), nil
 }
 
+//NetworkAt returns the network found at the given position.
+func (d *Dry) NetworkAt(pos int) (*types.NetworkResource, error) {
+	return d.dockerDaemon.NetworkAt(pos)
+}
+
 //OuputChannel returns the channel where dry messages are written
 func (d *Dry) OuputChannel() <-chan string {
 	return d.output
@@ -287,6 +292,18 @@ func (d *Dry) RemoveImage(id string, force bool) {
 		d.appmessage(fmt.Sprintf("<red>Removed image:</> <white>%s</>", shortID))
 	} else {
 		d.appmessage(fmt.Sprintf("<red>Error removing image </><white>%s: %s</>", shortID, err.Error()))
+	}
+}
+
+//RemoveNetwork removes the Docker network with the given id
+func (d *Dry) RemoveNetwork(id string) {
+	shortID := drydocker.TruncateID(id)
+	d.appmessage(fmt.Sprintf("<red>Removing network:</> <white>%s</>", shortID))
+	if err := d.dockerDaemon.RemoveNetwork(id); err == nil {
+		d.doRefresh()
+		d.appmessage(fmt.Sprintf("<red>Removed network:</> <white>%s</>", shortID))
+	} else {
+		d.appmessage(fmt.Sprintf("<red>Error network image </><white>%s: %s</>", shortID, err.Error()))
 	}
 }
 

--- a/app/dry_refresh_test.go
+++ b/app/dry_refresh_test.go
@@ -40,7 +40,6 @@ func newDryForTest() *Dry {
 		showingAllContainers: false,
 		SortMode:             docker.SortByContainerID,
 		viewMode:             Main,
-		mutex:                &sync.Mutex{},
 	}
 	dry.dockerDaemon = new(mocks.ContainerDaemonMock)
 	dry.refreshTimerMutex = &sync.Mutex{}

--- a/app/help_texts.go
+++ b/app/help_texts.go
@@ -77,22 +77,19 @@ Visit <blue>http://moncho.github.io/dry/</> for more information.
 
 const (
 	commonMappings = "<b>[H]:<darkgrey>Help</> <b>[Q]:<darkgrey>Quit</> <blue>|</> "
-	inspectMapping = "<b>[Enter]:<darkgrey>Commands</></>"
 	keyMappings    = commonMappings +
 		"<b>[F1]:<darkgrey>Sort</> <b>[F2]:<darkgrey>Toggle Show Containers</> <b>[F5]:<darkgrey>Refresh</> <b>[F9]:<darkgrey>Docker Events</> <b>[F10]:<darkgrey>Docker Info</> <blue>|</> " +
-		"<b>[2]:<darkgrey>Images</> <b>[3]:<darkgrey>Networks</><blue>|</>" +
-		inspectMapping
+		"<b>[2]:<darkgrey>Images</> <b>[3]:<darkgrey>Networks</><blue>|</> <b>[Enter]:<darkgrey>Commands</></>"
 
 	imagesKeyMappings = commonMappings +
 		"<b>[F1]:<darkgrey>Sort</> <b>[F5]:<darkgrey>Refresh</> <b>[F9]:<darkgrey>Docker Events</> <b>[F10]:<darkgrey>Docker Info</> <blue>|</> " +
 		"<b>[1]:<darkgrey>Containers</> <b>[3]:<darkgrey>Networks</> <blue>|</>" +
-		"<b>[Crtl+D]:<darkgrey>Remove Dangling</> <b>[Crtl+E]:<darkgrey>Remove</> <b>[Crtl+F]:<darkgrey>Force Remove</> <b>[I]:<darkgrey>History</> <blue>|</>" +
-		inspectMapping
+		"<b>[Crtl+D]:<darkgrey>Remove Dangling</> <b>[Crtl+E]:<darkgrey>Remove</> <b>[Crtl+F]:<darkgrey>Force Remove</> <b>[I]:<darkgrey>History</> <blue>|</>"
 
 	networkKeyMappings = commonMappings +
 		"<b>[F1]:<darkgrey>Sort</> <b>[F5]:<darkgrey>Refresh</> <b>[F9]:<darkgrey>Docker Events</> <b>[F10]:<darkgrey>Docker Info</> <blue>|</> " +
 		"<b>[1]:<darkgrey>Containers</> <b>[2]:<darkgrey>Images</><blue>|</>" +
-		inspectMapping
+		"<b>[Crtl+E]:<darkgrey>Remove</> <b>[Enter]:<darkgrey>Inspect</>"
 
 	commandsMenuBar = "<b>[Esc]:<darkgrey>Back</> <b>[Up]:<darkgrey>Cursor Up</> <b>[Down]:<darkgrey>Cursor Down</> <b>[Intro]:<darkgrey>Execute Command</>"
 )

--- a/app/loop.go
+++ b/app/loop.go
@@ -66,18 +66,12 @@ func RenderLoop(dry *Dry, screen *ui.Screen) {
 	//renders dry on message until renderChan is closed
 	go func() {
 		for {
-			select {
-			case <-timer.C:
-				timestamp := time.Now().Format(`15:04:05`)
-				screen.RenderLine(0, 0, `<right><white>`+timestamp+`</></right>`)
-				screen.Flush()
-			case _, ok := <-renderChan:
-				if ok {
-					screen.Clear()
-					Render(dry, screen, statusBar)
-				} else {
-					return
-				}
+			_, ok := <-renderChan
+			if ok {
+				screen.Clear()
+				Render(dry, screen, statusBar)
+			} else {
+				return
 			}
 		}
 	}()

--- a/app/network_events.go
+++ b/app/network_events.go
@@ -41,6 +41,16 @@ func (h networksScreenEventHandler) handle(renderChan chan<- struct{}, event ter
 		dry.InspectNetworkAt(cursorPos)
 		focus = false
 		go appui.Less(renderDry(dry), screen, h.keyboardQueueForView, h.viewClosed)
+	case termbox.KeyCtrlE: //remove network
+		if cursorPos >= 0 {
+			network, err := dry.NetworkAt(cursorPos)
+			if err == nil {
+				dry.RemoveNetwork(network.ID)
+				cursor.ScrollCursorDown()
+			} else {
+				ui.ShowErrorMessage(screen, h.keyboardQueueForView, h.viewClosed, err)
+			}
+		}
 	}
 
 	switch event.Ch {

--- a/app/render.go
+++ b/app/render.go
@@ -88,7 +88,7 @@ func Render(d *Dry, screen *ui.Screen, statusBar *ui.StatusBar) {
 
 	}
 	renderViewTitle(screen, what, count)
-	screen.RenderLineWithBackGround(0, screen.Height-1, keymap, ui.MenuBarBackgroundColor)
+	screen.RenderLineWithBackGround(0, screen.Height-1, keymap, appui.DryTheme.Footer)
 	d.setChanged(false)
 
 	screen.Flush()

--- a/appui/command.go
+++ b/appui/command.go
@@ -16,13 +16,10 @@ type ContainerCommandList struct {
 func NewContainerCommands(container types.Container, x, y, height, width int) *ContainerCommandList {
 	l := termui.NewList()
 
-	//shortID := docker.TruncateID(container.ID)
 	commandsLen := len(docker.CommandDescriptions)
 	commands := make([]string, commandsLen)
 	l.Items = commands
 	l.Border = false
-	//l.BorderLabel =
-	//	fmt.Sprintf(" %s - %s ", container.Names[0], shortID)
 	l.BorderFg = termui.ColorBlue
 	l.Height = len(commands) + 4 // 2 because of the top+bottom padding, 2 because of the borders
 	l.Width = width / 2

--- a/appui/container.go
+++ b/appui/container.go
@@ -27,8 +27,7 @@ func NewContainerInfo(container types.Container) (string, int) {
 	}
 	data := [][]string{
 		[]string{ui.Blue("Container Name:"), ui.Yellow(container.Names[0]), ui.Blue("ID:"), ui.Yellow(docker.TruncateID(container.ID)), ui.Blue("Status:"), status},
-		[]string{ui.Blue("Image:"), ui.Yellow(container.Image)},
-		[]string{ui.Blue("Created:"), ui.Yellow(docker.DurationForHumans(container.Created))},
+		[]string{ui.Blue("Image:"), ui.Yellow(container.Image), ui.Blue("Created:"), ui.Yellow(docker.DurationForHumans(container.Created) + " ago")},
 		[]string{ui.Blue("Command:"), ui.Yellow(container.Command)},
 		[]string{ui.Blue("Port mapping:"), ui.Yellow(docker.DisplayablePorts(container.Ports))},
 	}

--- a/appui/container.go
+++ b/appui/container.go
@@ -2,11 +2,16 @@ package appui
 
 import (
 	"bytes"
+	"strconv"
 
 	"github.com/docker/engine-api/types"
 	"github.com/moncho/dry/docker"
 	"github.com/moncho/dry/ui"
 	"github.com/olekukonko/tablewriter"
+)
+
+const (
+	maxWidth = 80
 )
 
 //ContainerInfo is a Bufferer holding the list of container commands
@@ -25,6 +30,7 @@ func NewContainerInfo(container types.Container) (string, int) {
 	} else {
 		status = ui.Red(container.Status)
 	}
+	lines := len(container.Command) / maxWidth
 	data := [][]string{
 		[]string{ui.Blue("Container Name:"), ui.Yellow(container.Names[0]), ui.Blue("ID:"), ui.Yellow(docker.TruncateID(container.ID)), ui.Blue("Status:"), status},
 		[]string{ui.Blue("Image:"), ui.Yellow(container.Image), ui.Blue("Created:"), ui.Yellow(docker.DurationForHumans(container.Created) + " ago")},
@@ -36,19 +42,22 @@ func NewContainerInfo(container types.Container) (string, int) {
 	for k, v := range container.NetworkSettings.Networks {
 		networkNames = append(networkNames, ui.Blue("Network Name: "))
 		networkNames = append(networkNames, ui.Yellow(k))
-		networkIps = append(networkIps, ui.Blue("IP Address:"))
+		networkIps = append(networkIps, ui.Blue("\tIP Address:"))
 		networkIps = append(networkIps, ui.Yellow(v.IPAddress))
 	}
 	data = append(data, networkNames)
 	data = append(data, networkIps)
+
+	data = append(data, []string{ui.Blue("Labels"), ui.Yellow(
+		strconv.Itoa(len(container.Labels)))})
 
 	table := tablewriter.NewWriter(buffer)
 	table.SetAutoFormatHeaders(false)
 	table.SetBorder(false)
 	table.SetColumnSeparator("")
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
-	table.SetColWidth(50)
+	table.SetColWidth(maxWidth)
 	table.AppendBulk(data)
 	table.Render()
-	return buffer.String(), len(data)
+	return buffer.String(), len(data) + lines
 }

--- a/appui/input.go
+++ b/appui/input.go
@@ -1,0 +1,6 @@
+package appui
+
+//Input reads input
+func Input(done chan<- struct{}) {
+	done <- struct{}{}
+}

--- a/appui/ps.go
+++ b/appui/ps.go
@@ -38,7 +38,6 @@ func NewDockerPsRenderData(containers []types.Container, selectedContainer int, 
 
 //DockerPs knows how render a container list
 type DockerPs struct {
-	appHeadear             *ui.Renderer
 	columns                []column // List of columns.
 	containerTableTemplate *template.Template
 	containerTemplate      *template.Template
@@ -54,10 +53,9 @@ func NewDockerPsRenderer(daemon docker.ContainerDaemon, screenHeight int) *Docke
 	r := &DockerPs{}
 
 	r.columns = []column{
-		{`ID`, `CONTAINER ID`, docker.SortByContainerID},
+		{`ID`, `CONTAINER`, docker.SortByContainerID},
 		{`Image`, `IMAGE`, docker.SortByImage},
 		{`Command`, `COMMAND`, docker.NoSort},
-		{`Created`, `CREATED`, docker.NoSort},
 		{`Status`, `STATUS`, docker.SortByStatus},
 		{`Ports`, `PORTS`, docker.NoSort},
 		{`Names`, `NAMES`, docker.SortByName},

--- a/appui/stats.go
+++ b/appui/stats.go
@@ -13,6 +13,10 @@ import (
 	"github.com/nsf/termbox-go"
 )
 
+const (
+	statsHeight = 4
+)
+
 type statsRenderer struct {
 	stats *drydocker.Stats
 }
@@ -56,7 +60,7 @@ func (r *statsRenderer) Render() string {
 //NewDockerStatsBufferer creates termui bufferer for docker stats
 func NewDockerStatsBufferer(stats *drydocker.Stats, x, y, height, width int) []termui.Bufferer {
 	var result []termui.Bufferer
-	top, length := NewDockerTopBufferer(stats.ProcessList, 0, y, height, width)
+	top, length := NewDockerTopBufferer(stats.ProcessList, 0, y, height-statsHeight, width)
 	result = append(result,
 		top)
 	yPos := y + length
@@ -77,7 +81,7 @@ func NewDockerStatsBufferer(stats *drydocker.Stats, x, y, height, width int) []t
 	p := termui.NewPar(buf.String())
 	p.X = x
 	p.Y = yPos
-	p.Height = height
+	p.Height = statsHeight
 	p.Width = width
 	p.TextFgColor = termui.Attribute(termbox.ColorYellow)
 	p.BorderLabel = " STATS "

--- a/appui/theme.go
+++ b/appui/theme.go
@@ -1,0 +1,70 @@
+package appui
+
+import (
+	"github.com/moncho/dry/ui"
+	"github.com/nsf/termbox-go"
+)
+
+//ColorTheme is the color theme for dry
+type ColorTheme struct {
+	Fg           ui.Color
+	Bg           ui.Color
+	DarkBg       ui.Color
+	Prompt       ui.Color
+	Key          ui.Color
+	Current      ui.Color
+	CurrentMatch ui.Color
+	Spinner      ui.Color
+	Info         ui.Color
+	Cursor       ui.Color
+	Selected     ui.Color
+	Header       ui.Color
+}
+
+//Default16 default theme for 16-color mode
+var Default16 = &ColorTheme{
+	Fg:           15,
+	Bg:           0,
+	DarkBg:       ui.Color(termbox.ColorBlack),
+	Prompt:       ui.Color(termbox.ColorBlue),
+	Key:          ui.Color(termbox.ColorGreen),
+	Current:      ui.Color(termbox.ColorYellow),
+	CurrentMatch: ui.Color(termbox.ColorGreen),
+	Spinner:      ui.Color(termbox.ColorGreen),
+	Info:         ui.Color(termbox.ColorWhite),
+	Cursor:       ui.Color(termbox.ColorRed),
+	Selected:     ui.Color(termbox.ColorMagenta),
+	Header:       ui.Color(termbox.ColorCyan)}
+
+//Dark256 dark theme for 256-color mode
+var Dark256 = &ColorTheme{
+	Fg:           15,
+	Bg:           0,
+	DarkBg:       236,
+	Prompt:       110,
+	Key:          108,
+	Current:      254,
+	CurrentMatch: 151,
+	Spinner:      148,
+	Info:         144,
+	Cursor:       161,
+	Selected:     168,
+	Header:       109}
+
+//Light256 light theme for 256-color mode
+var Light256 = &ColorTheme{
+	Fg:           15,
+	Bg:           0,
+	DarkBg:       251,
+	Prompt:       25,
+	Key:          66,
+	Current:      237,
+	CurrentMatch: 23,
+	Spinner:      65,
+	Info:         101,
+	Cursor:       161,
+	Selected:     168,
+	Header:       31}
+
+//DryTheme is the active theme for dry
+var DryTheme = Dark256

--- a/appui/theme.go
+++ b/appui/theme.go
@@ -5,24 +5,8 @@ import (
 	"github.com/nsf/termbox-go"
 )
 
-//ColorTheme is the color theme for dry
-type ColorTheme struct {
-	Fg           ui.Color
-	Bg           ui.Color
-	DarkBg       ui.Color
-	Prompt       ui.Color
-	Key          ui.Color
-	Current      ui.Color
-	CurrentMatch ui.Color
-	Spinner      ui.Color
-	Info         ui.Color
-	Cursor       ui.Color
-	Selected     ui.Color
-	Header       ui.Color
-}
-
 //Default16 default theme for 16-color mode
-var Default16 = &ColorTheme{
+var Default16 = &ui.ColorTheme{
 	Fg:           15,
 	Bg:           0,
 	DarkBg:       ui.Color(termbox.ColorBlack),
@@ -34,10 +18,11 @@ var Default16 = &ColorTheme{
 	Info:         ui.Color(termbox.ColorWhite),
 	Cursor:       ui.Color(termbox.ColorRed),
 	Selected:     ui.Color(termbox.ColorMagenta),
-	Header:       ui.Color(termbox.ColorCyan)}
+	Header:       ui.Color(termbox.ColorCyan),
+	Footer:       ui.Color(termbox.ColorCyan)}
 
 //Dark256 dark theme for 256-color mode
-var Dark256 = &ColorTheme{
+var Dark256 = &ui.ColorTheme{
 	Fg:           15,
 	Bg:           0,
 	DarkBg:       236,
@@ -49,10 +34,11 @@ var Dark256 = &ColorTheme{
 	Info:         144,
 	Cursor:       161,
 	Selected:     168,
-	Header:       109}
+	Header:       ui.MenuBarBackgroundColor,
+	Footer:       ui.MenuBarBackgroundColor}
 
 //Light256 light theme for 256-color mode
-var Light256 = &ColorTheme{
+var Light256 = &ui.ColorTheme{
 	Fg:           15,
 	Bg:           0,
 	DarkBg:       251,
@@ -64,7 +50,8 @@ var Light256 = &ColorTheme{
 	Info:         101,
 	Cursor:       161,
 	Selected:     168,
-	Header:       31}
+	Header:       31,
+	Footer:       31}
 
 //DryTheme is the active theme for dry
 var DryTheme = Dark256

--- a/docker/commands.go
+++ b/docker/commands.go
@@ -5,8 +5,10 @@ type Command int
 
 const (
 
+	//HISTORY Image history command
+	HISTORY Command = iota
 	//INSPECT Inspect command
-	INSPECT Command = iota
+	INSPECT
 	//KILL kill command
 	KILL
 	//LOGS logs command
@@ -23,11 +25,12 @@ const (
 
 //ContainerCommands is the list of container commands
 var ContainerCommands = []CommandDescription{
-	CommandDescription{INSPECT, "  Display container low-level information"},
-	CommandDescription{KILL, "  Kill container"},
 	CommandDescription{LOGS, "  Fetch logs"},
+	CommandDescription{INSPECT, "  Inspect container"},
+	CommandDescription{KILL, "  Kill container"},
 	CommandDescription{RM, "  Remove container"},
 	CommandDescription{RESTART, "  Restart"},
+	CommandDescription{HISTORY, "  Show image history"},
 	CommandDescription{STATS, "  Stats + Top"},
 	CommandDescription{STOP, "  Stop"},
 }

--- a/docker/container_formatter.go
+++ b/docker/container_formatter.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"strconv"
@@ -61,12 +62,14 @@ func (c *ContainerFormatter) Image() string {
 	if c.c.Image == "" {
 		return "<no image>"
 	}
-	//No ImageID field on the go-docker API yet
-	//if c.trunc {
-	//if stringid.TruncateID(c.c.ImageID) == stringid.TruncateID(c.c.Image) {
-	//			return stringutils.Truncate(c.c.Image, 12)
-	//		}
-	//}
+	imageLen := len(c.c.Image)
+	if c.trunc && imageLen > 40 {
+		var buffer bytes.Buffer
+		buffer.WriteString(c.c.Image[:18])
+		buffer.WriteString("...")
+		buffer.WriteString(c.c.Image[imageLen-18 : imageLen])
+		return buffer.String()
+	}
 	return c.c.Image
 }
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -383,6 +383,14 @@ func (daemon *DockerDaemon) RemoveDanglingImages() (int, error) {
 	return int(atomic.LoadUint32(&count)), err
 }
 
+//RemoveNetwork removes the network with the given id
+func (daemon *DockerDaemon) RemoveNetwork(id string) error {
+	//TODO use cancel function
+	ctx, _ := context.WithTimeout(context.Background(), defaultOperationTimeout)
+
+	return daemon.client.NetworkRemove(ctx, id)
+}
+
 //Rmi removes the image with the given name
 func (daemon *DockerDaemon) Rmi(name string, force bool) ([]dockerTypes.ImageDelete, error) {
 	options := dockerTypes.ImageRemoveOptions{

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -13,6 +13,7 @@ import (
 	dockerTypes "github.com/docker/engine-api/types"
 	dockerEvents "github.com/docker/engine-api/types/events"
 	"github.com/docker/engine-api/types/filters"
+	pkgError "github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -475,7 +476,7 @@ func containers(client dockerAPI.APIClient, allContainers bool) ([]dockerTypes.C
 		}
 		return containers, cmap, nil
 	}
-	return nil, nil, err
+	return nil, nil, pkgError.Wrap(err, "Error retrieving container list")
 }
 
 func images(client dockerAPI.APIClient, opts dockerTypes.ImageListOptions) ([]dockerTypes.Image, error) {

--- a/docker/formatter.go
+++ b/docker/formatter.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	//DefaultTableFormat is the default table format to render a list of containers
-	DefaultTableFormat = "{{.ID}}\t{{.Image}}\t{{.Command}}\t{{.RunningFor}} ago\t{{.Status}}\t{{.Ports}}\t{{.Names}}"
+	DefaultTableFormat = "{{.ID}}\t{{.Image}}\t{{.Command}}\t{{.Status}}\t{{.Ports}}\t{{.Names}}"
 	//DefaultImageTableFormat is the default table format to render a list of images
 	DefaultImageTableFormat = "{{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedSince}} ago\t{{.Size}}"
 	//DefaultNetworkTableFormat is the default table format to render a list of networks

--- a/docker/types.go
+++ b/docker/types.go
@@ -40,6 +40,7 @@ type ContainerDaemon interface {
 	RefreshNetworks() error
 	RemoveAllStoppedContainers() (int, error)
 	RemoveDanglingImages() (int, error)
+	RemoveNetwork(id string) error
 	Stats(id string) (<-chan *Stats, chan<- struct{})
 	StopContainer(id string) error
 	Sort(sortMode SortMode)

--- a/main.go
+++ b/main.go
@@ -189,9 +189,11 @@ func main() {
 	if err == nil {
 		app.RenderLoop(dry, screen)
 		dry.Close()
+		screen.Close()
 	} else {
+		//screen has to be closed before logging
+		screen.Close()
 		log.WithField("error", err).Error(
 			"There was an error launching dry")
 	}
-	screen.Close()
 }

--- a/mocks/ContainerDaemon.go
+++ b/mocks/ContainerDaemon.go
@@ -223,6 +223,11 @@ func (_m *ContainerDaemonMock) RemoveDanglingImages() (int, error) {
 	return 0, nil
 }
 
+//RemoveNetwork mock
+func (_m *ContainerDaemonMock) RemoveNetwork(id string) error {
+	return nil
+}
+
 // Stats provides a mock function with given fields: id
 func (_m *ContainerDaemonMock) Stats(id string) (<-chan *drydocker.Stats, chan<- struct{}) {
 

--- a/search/search.go
+++ b/search/search.go
@@ -7,17 +7,6 @@ import (
 
 import "fmt"
 
-const (
-	lines = `line 1
-	lien 2
-	line3
-line 4
-line 5
-Nope
-Still nope
-Really, nope`
-)
-
 //Result describes the results of a search
 type Result struct {
 	Hits    int
@@ -59,9 +48,9 @@ func (result *Result) String() string {
 // * InitialLine(3) will set the internal iteration index at 1.
 // * InitialLine(4) will set the internal iteration index at 1.
 // * InitialLine(10) will set the internal iteration index at 2.
-func (result *Result) InitialLine(lineNumber int) error {
+func (result *Result) InitialLine(lineNumber int) (int, error) {
 	if result.Lines == nil {
-		return nohitsError()
+		return -1, nohitsError()
 	}
 	candidate := 0
 	for i, line := range result.Lines {
@@ -72,7 +61,7 @@ func (result *Result) InitialLine(lineNumber int) error {
 		}
 	}
 	result.index = candidate
-	return nil
+	return candidate, nil
 }
 
 //NextLine returns the previous line while iterating the search results.

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -7,6 +7,15 @@ import (
 
 const (
 	searchPattern = "line"
+
+	lines = `line 1
+		lien 2
+		line3
+	line 4
+	line 5
+	Nope
+	Still nope
+	Really, nope`
 )
 
 //TestSearch tests basic search

--- a/ui/color.go
+++ b/ui/color.go
@@ -2,12 +2,15 @@ package ui
 
 import "fmt"
 
+//Color representation
+type Color uint16
+
 //Colors
 const (
-	MenuBarBackgroundColor = 0x19
-	Grey                   = 0xE9
-	Grey2                  = 0xF4
-	Darkgrey               = 0xE8
+	MenuBarBackgroundColor Color = 0x19
+	Grey                   Color = 0xE9
+	Grey2                  Color = 0xF4
+	Darkgrey               Color = 0xE8
 )
 
 //Blue blues the given string

--- a/ui/input.go
+++ b/ui/input.go
@@ -262,7 +262,7 @@ mainloop:
 //NewInputBox creates an input box, located at position x,y in the screen.
 func NewInputBox(x, y int, prompt string, output chan<- string, keyboardQueue chan termbox.Event) *InputBox {
 	width, _ := termbox.Size()
-	renderString(x, y, width, prompt, termbox.ColorWhite, termbox.ColorDefault)
+	renderString(x, y, width, prompt, termbox.ColorYellow, termbox.ColorDefault)
 	termbox.Flush()
 	return &InputBox{x: x + len(prompt), y: y, output: output, eventQueue: keyboardQueue}
 }

--- a/ui/less.go
+++ b/ui/less.go
@@ -144,7 +144,7 @@ func (less *Less) Search(pattern string) error {
 
 func (less *Less) readInput(inputBoxEventChan chan termbox.Event, inputBoxOuput chan string) error {
 	_, height := less.ViewSize()
-	eb := NewInputBox(0, height, "/", inputBoxOuput, inputBoxEventChan)
+	eb := NewInputBox(0, height, ">>>", inputBoxOuput, inputBoxEventChan)
 	eb.Focus()
 	return nil
 }
@@ -357,5 +357,4 @@ func (less *Less) drawCursor() {
 
 func clear() {
 	termbox.Clear(termbox.ColorDefault, termbox.ColorDefault)
-	//termbox.Flush()
 }

--- a/ui/less.go
+++ b/ui/less.go
@@ -131,8 +131,11 @@ func (less *Less) Search(pattern string) error {
 		searchResult, err := search.NewSearch(less.lines, pattern)
 		if err == nil {
 			less.searchResult = searchResult
-			_, y := less.Position()
-			searchResult.InitialLine(y)
+			if searchResult.Hits > 0 {
+				_, y := less.Position()
+				searchResult.InitialLine(y)
+				less.gotoNextSearchHit()
+			}
 		} else {
 			return err
 		}

--- a/ui/markup.go
+++ b/ui/markup.go
@@ -35,9 +35,9 @@ func tags() map[string]termbox.Attribute {
 	tags[`cyan`] = termbox.ColorCyan
 	tags[`cyan0`] = termbox.ColorCyan
 	tags[`white`] = termbox.ColorWhite
-	tags[`grey`] = Grey
-	tags[`grey2`] = Grey2
-	tags[`darkgrey`] = Darkgrey
+	tags[`grey`] = termbox.Attribute(Grey)
+	tags[`grey2`] = termbox.Attribute(Grey2)
+	tags[`darkgrey`] = termbox.Attribute(Darkgrey)
 	tags[`right`] = termbox.ColorDefault // Termbox can combine attributes and a single color using bitwise OR.
 	tags[`b`] = termbox.AttrBold
 	tags[`u`] = termbox.AttrUnderline

--- a/ui/screen.go
+++ b/ui/screen.go
@@ -149,7 +149,7 @@ func (screen *Screen) RenderLine(x int, y int, str string) {
 
 //RenderLineWithBackGround does what RenderLine does but rendering the line
 //with the given background color
-func (screen *Screen) RenderLineWithBackGround(x int, y int, str string, bgColor uint16) {
+func (screen *Screen) RenderLineWithBackGround(x int, y int, str string, bgColor Color) {
 	screen.termboxMutex.Lock()
 	defer screen.termboxMutex.Unlock()
 	start, column := 0, 0

--- a/ui/theme.go
+++ b/ui/theme.go
@@ -1,0 +1,18 @@
+package ui
+
+//ColorTheme represents a color theme
+type ColorTheme struct {
+	Fg           Color
+	Bg           Color
+	DarkBg       Color
+	Prompt       Color
+	Key          Color
+	Current      Color
+	CurrentMatch Color
+	Spinner      Color
+	Info         Color
+	Cursor       Color
+	Selected     Color
+	Header       Color
+	Footer       Color
+}

--- a/ui/view.go
+++ b/ui/view.go
@@ -201,8 +201,7 @@ func (v *View) clearRunes() {
 
 // writeRune writes a rune into the view's internal buffer, at the
 // position corresponding to the point (x, y). The length of the internal
-// buffer is increased if the point is out of bounds. Overwrite mode is
-// governed by the value of View.overwrite.
+// buffer is increased if the point is out of bounds.
 func (v *View) writeRune(x, y int, ch rune) error {
 	v.tainted = true
 

--- a/vendor/github.com/pkg/errors/.gitignore
+++ b/vendor/github.com/pkg/errors/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.4.3
+  - 1.5.4
+  - 1.6.2
+  - tip
+
+script:
+  - go test -v ./...

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,50 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+
+Package errors provides simple error handling primitives.
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## Licence
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,211 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type Causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type stacktracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stacktrace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stacktrace of this error. For example:
+//
+//     if err, ok := err.(stacktracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// _error is an error implementation returned by New and Errorf
+// that implements its own fmt.Formatter.
+type _error struct {
+	msg string
+	*stack
+}
+
+func (e _error) Error() string { return e.msg }
+
+func (e _error) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, e.msg)
+			fmt.Fprintf(s, "%+v", e.StackTrace())
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, e.msg)
+	}
+}
+
+// New returns an error with the supplied message.
+func New(message string) error {
+	return _error{
+		message,
+		callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+func Errorf(format string, args ...interface{}) error {
+	return _error{
+		fmt.Sprintf(format, args...),
+		callers(),
+	}
+}
+
+type cause struct {
+	cause error
+	msg   string
+}
+
+func (c cause) Error() string { return fmt.Sprintf("%s: %v", c.msg, c.Cause()) }
+func (c cause) Cause() error  { return c.cause }
+
+// wrapper is an error implementation returned by Wrap and Wrapf
+// that implements its own fmt.Formatter.
+type wrapper struct {
+	cause
+	*stack
+}
+
+func (w wrapper) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			fmt.Fprintf(s, "%+v: %s", w.StackTrace()[0], w.msg)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return wrapper{
+		cause: cause{
+			cause: err,
+			msg:   message,
+		},
+		stack: callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return wrapper{
+		cause: cause{
+			cause: err,
+			msg:   fmt.Sprintf(format, args...),
+		},
+		stack: callers(),
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type Causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,165 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
+}


### PR DESCRIPTION
Minor release.

### Improvements
A few visual changes here and there: 
* Created column removed from container list. Also reduced available space to print image name.
* Stats + top screen always shows stats information regardless of the amount of processes running.
* Nicer prompt.
* Search now moves the cursor to the first search occurrence. 

Also:
* Added remove network command. **[Ctrl+E]**.

### Notices
Release built using the stable version of Go 1.7.