### PR TITLE
Remove cursor move on container, image, network delete

### DIFF
--- a/app/container_events.go
+++ b/app/container_events.go
@@ -148,7 +148,6 @@ func (h *containersScreenEventHandler) handleCommand(command commandToExecute) {
 		}
 	case docker.RM:
 		dry.Rm(id)
-		screen.Cursor.ScrollCursorDown()
 	case docker.STATS:
 		focus = false
 		go statsScreen(command.container, screen, dry, h.keyboardQueueForView, h.closeViewChan)

--- a/app/image_events.go
+++ b/app/image_events.go
@@ -25,10 +25,8 @@ func (h *imagesScreenEventHandler) handle(event termbox.Event) {
 		dry.RemoveDanglingImages()
 	case termbox.KeyCtrlE: //remove image
 		dry.RemoveImageAt(cursorPos, false)
-		cursor.ScrollCursorDown()
 	case termbox.KeyCtrlF: //force remove image
 		dry.RemoveImageAt(cursorPos, true)
-		cursor.ScrollCursorDown()
 	case termbox.KeyEnter: //inspect image
 		dry.InspectImageAt(cursorPos)
 		focus = false

--- a/app/network_events.go
+++ b/app/network_events.go
@@ -32,7 +32,6 @@ func (h *networksScreenEventHandler) handle(event termbox.Event) {
 			network, err := dry.NetworkAt(cursorPos)
 			if err == nil {
 				dry.RemoveNetwork(network.ID)
-				cursor.ScrollCursorDown()
 			} else {
 				ui.ShowErrorMessage(screen, h.keyboardQueueForView, h.closeViewChan, err)
 			}


### PR DESCRIPTION
As I user I don't quite feel why cursor moves after removing container, image or network. For example, if I wanted to delete all images and I have my cursor on the first item, I need to press up arrow after every delete. My PR changes that, but if you have some arguments against it I'd love to hear them ;)