### PR TITLE
Remove state from docker layer

### DIFF
--- a/appui/images.go
+++ b/appui/images.go
@@ -129,25 +129,26 @@ func (r *DockerImagesRenderer) imageInformation() string {
 func (r *DockerImagesRenderer) imagesToShow() []types.ImageSummary {
 	images := r.data.images
 	cursorPos := r.data.selectedImage
-	linesForImages := ui.ActiveScreen.Dimensions.Height - imageTableStartPos - 1
+	//number of lines from the screen that can be used to render images
+	lines := ui.ActiveScreen.Dimensions.Height - imageTableStartPos - 1
 
-	if linesForImages < 0 {
+	if lines < 0 {
 		return nil
-	} else if len(images) < linesForImages {
+	} else if len(images) < lines {
 		return images
 	}
 
 	start, end := 0, 0
 
-	if cursorPos > linesForImages {
-		start = cursorPos + 1 - linesForImages
+	if cursorPos > lines {
+		start = cursorPos + 1 - lines
 		end = cursorPos + 1
-	} else if cursorPos == linesForImages {
+	} else if cursorPos == lines {
 		start = 1
-		end = linesForImages + 1
+		end = lines + 1
 	} else {
 		start = 0
-		end = linesForImages
+		end = lines
 	}
 
 	return images[start:end]

--- a/appui/monitor.go
+++ b/appui/monitor.go
@@ -23,7 +23,7 @@ type Monitor struct {
 //at the given position and with the given width.
 func NewMonitor(daemon docker.ContainerDaemon, y int) *Monitor {
 	height := ui.ActiveScreen.Dimensions.Height - MainScreenHeaderSize - MainScreenFooterSize - 2
-	containers := daemon.ContainerStore().Filter(docker.ContainerFilters.ByRunningState(true))
+	containers := daemon.Containers(docker.ContainerFilters.Running(), docker.SortByName)
 	var rows []*ContainerStatsRow
 	var channels []*docker.StatsChannel
 	for _, c := range containers {

--- a/appui/stats_row.go
+++ b/appui/stats_row.go
@@ -12,6 +12,8 @@ import (
 	drytermui "github.com/moncho/dry/ui/termui"
 )
 
+var inactiveRowColor = termui.Attribute(ui.Color244)
+
 //ContainerStatsRow is a Grid row showing runtime information about a container
 type ContainerStatsRow struct {
 	container *types.Container
@@ -187,17 +189,22 @@ func (row *ContainerStatsRow) setMem(val float64, limit float64, percent float64
 
 //markAsNotRunning
 func (row *ContainerStatsRow) markAsNotRunning() {
-	c := termui.Attribute(ui.Color244)
-	row.Name.TextFgColor = c
-	row.ID.TextFgColor = c
-	row.CPU.PercentColor = c
+
+	row.Name.TextFgColor = inactiveRowColor
+	row.ID.TextFgColor = inactiveRowColor
+	row.CPU.PercentColor = inactiveRowColor
 	row.CPU.Percent = 0
 	row.CPU.Label = "-"
-	row.Memory.PercentColor = c
+	row.Memory.PercentColor = inactiveRowColor
 	row.Memory.Percent = 0
 	row.Memory.Label = "-"
-	row.Net.TextFgColor = c
+	row.Net.TextFgColor = inactiveRowColor
+	row.Net.Text = "-"
+	row.Block.TextFgColor = inactiveRowColor
+	row.Block.Text = "-"
 	row.Pids.Text = "0"
+	row.Pids.TextFgColor = inactiveRowColor
+
 }
 
 func percentileToColor(n int) termui.Attribute {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -37,58 +37,43 @@ var defaultImageListOptions = dockerTypes.ImageListOptions{
 
 //DockerDaemon knows how to talk to the Docker daemon
 type DockerDaemon struct {
-	client         dockerAPI.APIClient //client used to to connect to the Docker daemon
-	containerStore *ContainerStore
-	images         []dockerTypes.ImageSummary
-	networks       []dockerTypes.NetworkResource
-	err            error // Errors, if any.
-	connected      bool
-	dockerEnv      *Env
-	version        *dockerTypes.Version
-	refreshLock    sync.Mutex
-	eventLog       *EventLog
+	client       dockerAPI.APIClient //client used to to connect to the Docker daemon
+	s            ContainerStore
+	images       []dockerTypes.ImageSummary
+	networks     []dockerTypes.NetworkResource
+	err          error // Errors, if any.
+	connected    bool
+	dockerEnv    *Env
+	version      *dockerTypes.Version
+	storeLock    sync.RWMutex
+	imagesLock   sync.RWMutex
+	networksLock sync.RWMutex
+
+	eventLog *EventLog
 }
 
 func init() {
 	log.SetOutput(os.Stderr)
 }
 
-//ContainerStore returns the container store
-func (daemon *DockerDaemon) ContainerStore() *ContainerStore {
-	return daemon.containerStore
-}
-
 //Containers returns the containers known by the daemon
-func (daemon *DockerDaemon) Containers() []*dockerTypes.Container {
-	return daemon.containerStore.List()
-}
-
-//ContainerAt returns the container at the given position
-func (daemon *DockerDaemon) ContainerAt(pos int) (*dockerTypes.Container, error) {
-	return daemon.containerStore.At(pos), nil
-}
-
-//ContainersCount returns the number of containers found.
-func (daemon *DockerDaemon) ContainersCount() int {
-	return daemon.containerStore.Size()
-}
-
-//ContainerIDAt returns the container ID of the container found at the given
-//position.
-func (daemon *DockerDaemon) ContainerIDAt(pos int) (string, string, error) {
-	if pos < 0 || pos >= daemon.ContainersCount() {
-		return "", "", fmt.Errorf("Invalid container position: %d", pos)
+func (daemon *DockerDaemon) Containers(filter ContainerFilter, mode SortMode) []*dockerTypes.Container {
+	c := daemon.store().List()
+	if filter != nil {
+		c = Filter(c, filter)
 	}
-	c := daemon.containerStore.At(pos)
-	if c == nil {
-		return "", "", fmt.Errorf("No container found at position: %d", pos)
-	}
-	return c.ID, TruncateID(c.ID), nil
+	SortContainers(c, mode)
+	return c
+}
+
+//ContainerCount returns the total number of containers.
+func (daemon *DockerDaemon) ContainerCount() int {
+	return daemon.store().Size()
 }
 
 //ContainerByID returns the container with the given ID
 func (daemon *DockerDaemon) ContainerByID(cid string) *dockerTypes.Container {
-	return daemon.containerStore.Get(cid)
+	return daemon.store().Get(cid)
 }
 
 //DiskUsage returns reported Docker disk usage
@@ -157,8 +142,8 @@ func (daemon *DockerDaemon) History(id string) ([]dockerTypes.ImageHistory, erro
 //ImageAt returns the Image found at the given
 //position.
 func (daemon *DockerDaemon) ImageAt(pos int) (*dockerTypes.ImageSummary, error) {
-	daemon.refreshLock.Lock()
-	defer daemon.refreshLock.Unlock()
+	daemon.imagesLock.Lock()
+	defer daemon.imagesLock.Unlock()
 	if pos >= len(daemon.images) {
 		return nil, errors.New("Position is higher than number of images")
 	}
@@ -167,15 +152,15 @@ func (daemon *DockerDaemon) ImageAt(pos int) (*dockerTypes.ImageSummary, error) 
 
 //Images returns the list of Docker images
 func (daemon *DockerDaemon) Images() ([]dockerTypes.ImageSummary, error) {
-	daemon.refreshLock.Lock()
-	defer daemon.refreshLock.Unlock()
+	daemon.imagesLock.Lock()
+	defer daemon.imagesLock.Unlock()
 	return daemon.images, nil
 }
 
 //ImagesCount returns the number of images
 func (daemon *DockerDaemon) ImagesCount() int {
-	daemon.refreshLock.Lock()
-	defer daemon.refreshLock.Unlock()
+	daemon.imagesLock.Lock()
+	defer daemon.imagesLock.Unlock()
 	return len(daemon.images)
 }
 
@@ -206,7 +191,7 @@ func (daemon *DockerDaemon) InspectImage(name string) (dockerTypes.ImageInspect,
 
 //IsContainerRunning returns true if the container with the given  is running
 func (daemon *DockerDaemon) IsContainerRunning(id string) bool {
-	return IsContainerRunning(daemon.containerStore.Get(id))
+	return IsContainerRunning(daemon.store().Get(id))
 }
 
 //Kill the container with the given id
@@ -237,15 +222,15 @@ func (daemon *DockerDaemon) Logs(id string) io.ReadCloser {
 
 //Networks returns the list of Docker networks
 func (daemon *DockerDaemon) Networks() ([]dockerTypes.NetworkResource, error) {
-	daemon.refreshLock.Lock()
-	defer daemon.refreshLock.Unlock()
+	daemon.networksLock.RLock()
+	defer daemon.networksLock.RUnlock()
 	return daemon.networks, nil
 }
 
 //NetworkAt returns the network found at the given position.
 func (daemon *DockerDaemon) NetworkAt(pos int) (*dockerTypes.NetworkResource, error) {
-	daemon.refreshLock.Lock()
-	defer daemon.refreshLock.Unlock()
+	daemon.networksLock.RLock()
+	defer daemon.networksLock.RUnlock()
 	if pos >= len(daemon.networks) {
 		return nil, errors.New("Position is higher than number of networks")
 	}
@@ -254,8 +239,8 @@ func (daemon *DockerDaemon) NetworkAt(pos int) (*dockerTypes.NetworkResource, er
 
 //NetworksCount returns the number of networks reported by Docker
 func (daemon *DockerDaemon) NetworksCount() int {
-	daemon.refreshLock.Lock()
-	defer daemon.refreshLock.Unlock()
+	daemon.networksLock.RLock()
+	defer daemon.networksLock.RUnlock()
 	return len(daemon.networks)
 }
 
@@ -273,6 +258,7 @@ func (daemon *DockerDaemon) Ok() (bool, error) {
 	return daemon.err == nil, daemon.err
 }
 
+//OpenChannel creates a channel with the runtime stats of the given container
 func (daemon *DockerDaemon) OpenChannel(container *dockerTypes.Container) *StatsChannel {
 	return NewStatsChannel(daemon, container)
 }
@@ -314,22 +300,36 @@ func (daemon *DockerDaemon) RestartContainer(id string) error {
 	ctx, _ := context.WithTimeout(context.Background(), defaultOperationTimeout)
 
 	//fixme: timeout to start a container
-	return daemon.client.ContainerRestart(ctx, id, &containerOpTimeout)
+	if err := daemon.client.ContainerRestart(ctx, id, &containerOpTimeout); err != nil {
+		return err
+	}
+	var wg sync.WaitGroup
+	var refreshError error
+	wg.Add(1)
+	daemon.Refresh(func(err error) {
+		refreshError = err
+		wg.Done()
+	})
+	wg.Wait()
+	return refreshError
 }
 
-//Refresh the container list
-func (daemon *DockerDaemon) Refresh(allContainers bool) error {
-	containers, err := containers(daemon.client, allContainers)
-	if err == nil {
-		daemon.containerStore = NewMemoryStoreWithContainers(containers)
-	}
-	return err
+//Refresh the container list asynchronously, using the given notifier to signal
+//operation completion.
+func (daemon *DockerDaemon) Refresh(notify func(error)) {
+	go func() {
+		store, err := NewDockerContainerStore(daemon.client)
+		if err == nil {
+			daemon.setStore(store)
+		}
+		notify(err)
+	}()
 }
 
 //RefreshImages refreshes the image list
 func (daemon *DockerDaemon) RefreshImages() error {
-	daemon.refreshLock.Lock()
-	defer daemon.refreshLock.Unlock()
+	daemon.imagesLock.Lock()
+	defer daemon.imagesLock.Unlock()
 
 	images, err := images(daemon.client, defaultImageListOptions)
 
@@ -341,8 +341,8 @@ func (daemon *DockerDaemon) RefreshImages() error {
 
 //RefreshNetworks refreshes the network list
 func (daemon *DockerDaemon) RefreshNetworks() error {
-	daemon.refreshLock.Lock()
-	defer daemon.refreshLock.Unlock()
+	daemon.networksLock.Lock()
+	defer daemon.networksLock.Unlock()
 
 	networks, err := networks(daemon.client)
 
@@ -354,38 +354,37 @@ func (daemon *DockerDaemon) RefreshNetworks() error {
 
 //RemoveAllStoppedContainers removes all stopped containers
 func (daemon *DockerDaemon) RemoveAllStoppedContainers() (int, error) {
-	containers, err := containers(daemon.client, true)
+	containers := daemon.Containers(ContainerFilters.NotRunning(), NoSort)
 	var count uint32
 	errs := make(chan error, 1)
 	defer close(errs)
-	if err == nil {
-		var wg sync.WaitGroup
-		for _, container := range containers {
-			if !IsContainerRunning(container) {
-				wg.Add(1)
-				go func(id string) {
-					defer atomic.AddUint32(&count, 1)
-					defer wg.Done()
-					err = daemon.Rm(id)
-					if err != nil {
-						select {
-						case errs <- err:
-						default:
-						}
-					} else {
-						daemon.containerStore.Delete(id)
-					}
-				}(container.ID)
+	var wg sync.WaitGroup
+	for _, container := range containers {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			err := daemon.Rm(id)
+			if err != nil {
+				select {
+				case errs <- err:
+				default:
+				}
+			} else {
+				atomic.AddUint32(&count, 1)
 			}
-		}
-		wg.Wait()
-		select {
-		case e := <-errs:
-			return 0, e
-		default:
-		}
+		}(container.ID)
 	}
-	return int(atomic.LoadUint32(&count)), err
+
+	wg.Wait()
+	removed := int(atomic.LoadUint32(&count))
+	select {
+	case e := <-errs:
+		return removed,
+			pkgError.Wrap(e,
+				fmt.Sprintf("There were errors removing stopped containers. Containers: %d, removed: %d", len(containers), removed))
+	default:
+	}
+	return removed, nil
 }
 
 //RemoveDanglingImages removes dangling images
@@ -434,7 +433,6 @@ func (daemon *DockerDaemon) RemoveNetwork(id string) error {
 
 //Rm removes the container with the given id
 func (daemon *DockerDaemon) Rm(id string) error {
-	daemon.containerStore.Delete(id)
 
 	go func() {
 		opts := dockerTypes.ContainerRemoveOptions{
@@ -446,8 +444,11 @@ func (daemon *DockerDaemon) Rm(id string) error {
 		ctx, _ := context.WithTimeout(context.Background(), defaultOperationTimeout)
 		err := daemon.client.ContainerRemove(ctx, id, opts)
 		if err != nil {
-			daemon.Refresh(true)
+			daemon.Refresh(nil)
+		} else {
+			daemon.store().Remove(id)
 		}
+
 	}()
 	return nil
 }
@@ -463,9 +464,21 @@ func (daemon *DockerDaemon) Rmi(name string, force bool) ([]dockerTypes.ImageDel
 	return daemon.client.ImageRemove(ctx, name, options)
 }
 
+func (daemon *DockerDaemon) setStore(store ContainerStore) {
+	daemon.storeLock.Lock()
+	defer daemon.storeLock.Unlock()
+	daemon.s = store
+}
+
+func (daemon *DockerDaemon) store() ContainerStore {
+	daemon.storeLock.RLock()
+	defer daemon.storeLock.RUnlock()
+	return daemon.s
+}
+
 //Stats shows resource usage statistics of the container with the given id
 func (daemon *DockerDaemon) Stats(id string) (<-chan *Stats, chan<- struct{}) {
-	stream := NewStatsChannel(daemon, daemon.containerStore.Get(id))
+	stream := NewStatsChannel(daemon, daemon.store().Get(id))
 	return stream.Stats, stream.Done
 }
 
@@ -477,22 +490,17 @@ func (daemon *DockerDaemon) StopContainer(id string) error {
 	return daemon.client.ContainerStop(ctx, id, &containerOpTimeout)
 }
 
-//Sort the list of containers by the given mode
-func (daemon *DockerDaemon) Sort(sortMode SortMode) {
-	daemon.containerStore.Sort(sortMode)
-}
-
 //SortImages sorts the list of images by the given mode
 func (daemon *DockerDaemon) SortImages(sortMode SortImagesMode) {
-	daemon.refreshLock.Lock()
-	defer daemon.refreshLock.Unlock()
+	daemon.imagesLock.Lock()
+	defer daemon.imagesLock.Unlock()
 	SortImages(daemon.images, sortMode)
 }
 
 //SortNetworks sortes the list of networks by the given mode
 func (daemon *DockerDaemon) SortNetworks(sortMode SortNetworksMode) {
-	daemon.refreshLock.Lock()
-	defer daemon.refreshLock.Unlock()
+	daemon.networksLock.Lock()
+	defer daemon.networksLock.Unlock()
 	SortNetworks(daemon.networks, sortMode)
 }
 
@@ -520,32 +528,31 @@ func (daemon *DockerDaemon) Version() (*dockerTypes.Version, error) {
 	return daemon.version, nil
 }
 
-func containers(client dockerAPI.APIClient, allContainers bool) ([]*dockerTypes.Container, error) {
+func containers(client dockerAPI.ContainerAPIClient) ([]*dockerTypes.Container, error) {
 	//TODO use cancel function
 	//Since this is how dry fist connects to the Docker daemon
 	//a different (longer) timeout is used.
 	ctx, _ := context.WithTimeout(context.Background(), DefaultConnectionTimeout)
 
-	containers, err := client.ContainerList(ctx, dockerTypes.ContainerListOptions{All: allContainers, Size: true})
+	containers, err := client.ContainerList(ctx, dockerTypes.ContainerListOptions{All: true, Size: true})
 	if err == nil {
 		var cPointers []*dockerTypes.Container
 		for i := range containers {
 			cPointers = append(cPointers, &containers[i])
 		}
-
 		return cPointers, nil
 	}
 	return nil, pkgError.Wrap(err, "Error retrieving container list")
 }
 
-func images(client dockerAPI.APIClient, opts dockerTypes.ImageListOptions) ([]dockerTypes.ImageSummary, error) {
+func images(client dockerAPI.ImageAPIClient, opts dockerTypes.ImageListOptions) ([]dockerTypes.ImageSummary, error) {
 	//TODO use cancel function
 	ctx, _ := context.WithTimeout(context.Background(), defaultOperationTimeout)
 
 	return client.ImageList(ctx, opts)
 }
 
-func networks(client dockerAPI.APIClient) ([]dockerTypes.NetworkResource, error) {
+func networks(client dockerAPI.NetworkAPIClient) ([]dockerTypes.NetworkResource, error) {
 	//TODO use cancel function
 	ctx, _ := context.WithTimeout(context.Background(), defaultOperationTimeout)
 

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestContainerListRetrieval(t *testing.T) {
-	c, _ := containers(createClient(), true)
+	c, _ := containers(createClient())
 
 	for i, container := range c {
 		if container.ID != strconv.Itoa(i) {
@@ -38,6 +38,6 @@ func TestContainerConversionToPointerList(t *testing.T) {
 		}
 	}
 }
-func createClient() dockerAPI.APIClient {
-	return mock.APIClientMock{}
+func createClient() dockerAPI.ContainerAPIClient {
+	return mock.ContainerAPIClientMock{}
 }

--- a/docker/filter.go
+++ b/docker/filter.go
@@ -45,3 +45,24 @@ func (c ContainerFilter) ByRunningState(running bool) ContainerFilter {
 		return IsContainerRunning(c) == running
 	}
 }
+
+//Running filters out container that are not running
+func (c ContainerFilter) Running() ContainerFilter {
+	return c.ByRunningState(true)
+}
+
+//NotRunning filters out container that are running
+func (c ContainerFilter) NotRunning() ContainerFilter {
+	return c.ByRunningState(false)
+}
+
+//Filter applies the given filter to the given slice of containers
+func Filter(c []*types.Container, filter ContainerFilter) []*types.Container {
+	var containers []*types.Container
+	for _, cont := range c {
+		if filter == nil || filter(cont) {
+			containers = append(containers, cont)
+		}
+	}
+	return containers
+}

--- a/docker/memory_store_test.go
+++ b/docker/memory_store_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	dockerTypes "github.com/docker/docker/api/types"
+	"github.com/moncho/dry/docker/mock"
 )
 
 var testContainers = createTestContainers(10)
@@ -12,13 +13,15 @@ var containerCount = len(testContainers)
 var hundredContainers = createTestContainers(100)
 
 func BenchmarkMemoryStoreContainerCreation(b *testing.B) {
+	c := mock.ContainerAPIClientMock{Containers: hundredContainers}
 	for i := 0; i < b.N; i++ {
-		NewMemoryStoreWithContainers(hundredContainers)
+		NewDockerContainerStore(c)
 	}
 }
 
 func BenchmarkMemoryStoreContainerListing(b *testing.B) {
-	memStore := NewMemoryStoreWithContainers(hundredContainers)
+	c := mock.ContainerAPIClientMock{Containers: hundredContainers}
+	memStore, _ := NewDockerContainerStore(c)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		memStore.List()
@@ -26,8 +29,8 @@ func BenchmarkMemoryStoreContainerListing(b *testing.B) {
 }
 
 func TestMemoryStoreCreation(t *testing.T) {
-
-	memStore := NewMemoryStoreWithContainers(testContainers)
+	c := mock.ContainerAPIClientMock{}
+	memStore, _ := NewDockerContainerStore(c)
 	if memStore == nil {
 		t.Error("Memstore is nil")
 	}
@@ -46,83 +49,11 @@ func TestMemoryStoreCreation(t *testing.T) {
 	checkMemoryStore(memStore, containerCount, t)
 }
 
-func TestMemoryStoreAddContainer(t *testing.T) {
-	memStore := NewMemoryStoreWithContainers(testContainers)
-	memStore.Add(&dockerTypes.Container{
-		ID: "11",
-	})
-
-	checkMemoryStore(memStore, containerCount+1, t)
-}
-
-func TestMemoryStoreAddDuplicatedContainer(t *testing.T) {
-	containerCount := containerCount
-	memStore := NewMemoryStoreWithContainers(testContainers)
-	memStore.Add(&dockerTypes.Container{
-		ID: "10",
-	})
-
-	memStore.Add(&dockerTypes.Container{
-		ID: "10",
-	})
-	containerCount++
-	containers := memStore.List()
-
-	checkMemoryStore(memStore, containerCount, t)
-
-	for i, c := range containers {
-		t.Log(c.ID)
-		if strconv.Itoa(i) != c.ID {
-			t.Errorf("Expected ID %d, got %s", i, c.ID)
-		}
-	}
-}
-
-func TestFilter(t *testing.T) {
-	memStore := NewMemoryStoreWithContainers(testContainers)
-	filter := func(c *dockerTypes.Container) bool {
-		return c.ID == "1"
-	}
-	filtered := memStore.Filter(filter)
-	checkMemoryStore(memStore, containerCount, t)
-
-	if len(filtered) != 1 || filtered[0].ID != "1" {
-		t.Errorf("Filter did not work, got %v", filtered)
-	}
-}
-
-func TestStoreFilterByName(t *testing.T) {
-	memStore := NewMemoryStoreWithContainers(testContainers)
-	filter := ContainerFilters.ByName("1")
-	filtered := memStore.Filter(filter)
-	checkMemoryStore(memStore, containerCount, t)
-
-	if len(filtered) != 1 || filtered[0].Names[0] != "Name1" {
-		t.Errorf("Filter did not work, got %v", filtered)
-	}
-
-	filtered = memStore.Filter(ContainerFilters.ByName("2"))
-	if len(filtered) != 1 || filtered[0].Names[0] != "Name2" {
-		t.Errorf("Filter did not work, got %v", filtered)
-	}
-}
-
-func TestContainerAt(t *testing.T) {
-	memStore := NewMemoryStoreWithContainers(testContainers)
-
-	container := memStore.At(0)
-	checkMemoryStore(memStore, containerCount, t)
-
-	if container == nil || container.ID != "0" {
-		t.Errorf("Container at did not work, got %v", container)
-	}
-}
-
-func createTestContainers(numberOfContainers int) []*dockerTypes.Container {
-	var containers []*dockerTypes.Container
+func createTestContainers(numberOfContainers int) []dockerTypes.Container {
+	var containers []dockerTypes.Container
 
 	for i := 0; i < numberOfContainers; i++ {
-		containers = append(containers, &dockerTypes.Container{
+		containers = append(containers, dockerTypes.Container{
 			ID:    strconv.Itoa(i),
 			Names: []string{"Name" + strconv.Itoa(i)},
 		})
@@ -131,7 +62,7 @@ func createTestContainers(numberOfContainers int) []*dockerTypes.Container {
 	return containers
 }
 
-func checkMemoryStore(memStore *ContainerStore, containerCount int, t *testing.T) {
+func checkMemoryStore(memStore *DockerContainerStore, containerCount int, t *testing.T) {
 	containers := memStore.List()
 	if memStore.Size() != containerCount {
 		t.Errorf("Memstore does not contain the expected the number of elements, expected: %d, got: %d", containerCount, memStore.Size())

--- a/docker/mock/docker_api_client.go
+++ b/docker/mock/docker_api_client.go
@@ -15,13 +15,27 @@ import (
 //directory of the vendor tool of dry, so:
 //rm -rf vendor/github.com/docker/docker/vendor/golang.org/x/
 
-//APIClientMock mocks docker APIClient
-type APIClientMock struct {
-	dockerAPI.APIClient
+//ContainerAPIClientMock mocks docker ContainerAPIClient
+type ContainerAPIClientMock struct {
+	dockerAPI.ContainerAPIClient
+	Containers []types.Container
+}
+
+//NetworkAPIClientMock mocks docker NetworkAPIClient
+type NetworkAPIClientMock struct {
+	dockerAPI.NetworkAPIClient
+}
+
+//ImageAPIClientMock mocks docker ImageAPIClient
+type ImageAPIClientMock struct {
+	dockerAPI.ImageAPIClient
 }
 
 //ContainerList returns a list with 10 container with IDs from 0 to 9.
-func (m APIClientMock) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+func (m ContainerAPIClientMock) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+	if len(m.Containers) > 0 {
+		return m.Containers, nil
+	}
 	var containers []types.Container
 
 	for i := 0; i < 10; i++ {

--- a/docker/sort.go
+++ b/docker/sort.go
@@ -62,6 +62,7 @@ func (a byName) Less(i, j int) bool {
 //SortContainers sorts the given containers slice using the given mode
 func SortContainers(containers []*types.Container, mode SortMode) {
 	switch mode {
+	case NoSort:
 	case SortByContainerID:
 		sort.Sort(byContainerID{containers})
 	case SortByImage:

--- a/docker/types.go
+++ b/docker/types.go
@@ -9,7 +9,7 @@ import (
 
 //ContainerDaemon describes what is expected from the container daemon
 type ContainerDaemon interface {
-	ContainerStore() *ContainerStore
+	ContainerAPI
 	DiskUsage() (types.DiskUsage, error)
 	DockerEnv() *Env
 	Events() (<-chan events.Message, chan<- struct{}, error)
@@ -19,33 +19,38 @@ type ContainerDaemon interface {
 	Images() ([]types.ImageSummary, error)
 	ImagesCount() int
 	Info() (types.Info, error)
-	Inspect(id string) (types.ContainerJSON, error)
 	InspectImage(id string) (types.ImageInspect, error)
-	IsContainerRunning(id string) bool
-	Kill(id string) error
-	Logs(id string) io.ReadCloser
 	Networks() ([]types.NetworkResource, error)
 	NetworkAt(pos int) (*types.NetworkResource, error)
 	NetworksCount() int
 	NetworkInspect(id string) (types.NetworkResource, error)
 	Ok() (bool, error)
-	OpenChannel(container *types.Container) *StatsChannel
 	Prune() (*PruneReport, error)
-	RestartContainer(id string) error
 	Rm(id string) error
 	Rmi(id string, force bool) ([]types.ImageDelete, error)
-	Refresh(allContainers bool) error
+	Refresh(notify func(error))
 	RefreshImages() error
 	RefreshNetworks() error
-	RemoveAllStoppedContainers() (int, error)
 	RemoveDanglingImages() (int, error)
 	RemoveNetwork(id string) error
-	StopContainer(id string) error
-	Sort(sortMode SortMode)
 	SortImages(sortMode SortImagesMode)
 	SortNetworks(sortMode SortNetworksMode)
-	Top(id string) (types.ContainerProcessList, error)
 	Version() (*types.Version, error)
+}
+
+//ContainerAPI defines the API for containers
+type ContainerAPI interface {
+	ContainerByID(id string) *types.Container
+	Containers(filter ContainerFilter, mode SortMode) []*types.Container
+	Inspect(id string) (types.ContainerJSON, error)
+	IsContainerRunning(id string) bool
+	Kill(id string) error
+	Logs(id string) io.ReadCloser
+	OpenChannel(container *types.Container) *StatsChannel
+	RemoveAllStoppedContainers() (int, error)
+	RestartContainer(id string) error
+	StopContainer(id string) error
+	Top(id string) (types.ContainerProcessList, error)
 }
 
 //Stats holds runtime stats for a container

--- a/mocks/container_daemon.go
+++ b/mocks/container_daemon.go
@@ -13,8 +13,13 @@ import (
 type ContainerDaemonMock struct {
 }
 
-//ContainerStore mock
-func (_m *ContainerDaemonMock) ContainerStore() *drydocker.ContainerStore {
+//ContainerByID mock
+func (_m *ContainerDaemonMock) ContainerByID(id string) *types.Container {
+	return nil
+}
+
+//Containers mock
+func (_m *ContainerDaemonMock) Containers(filter drydocker.ContainerFilter, mode drydocker.SortMode) []*types.Container {
 	return nil
 }
 
@@ -193,8 +198,8 @@ func (_m *ContainerDaemonMock) Rmi(id string, force bool) ([]types.ImageDelete, 
 }
 
 // Refresh provides a mock function with given fields: allContainers
-func (_m *ContainerDaemonMock) Refresh(allContainers bool) error {
-	return nil
+func (_m *ContainerDaemonMock) Refresh(notify func(err error)) {
+	notify(nil)
 }
 
 //RefreshImages mock


### PR DESCRIPTION
The docker layer does not hold the state of the container list anymore. Now it just provides the API to retrieve and manage containers. 

The specific ordering and filtering of the container list has been moved to the app layer.

This change still has to be done for images and networks.