### PR TITLE
Optimized Dockerfile for smaller image + dryup.sh ARM detection/download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 FROM alpine:latest
 
-# get dependancies
-RUN apk --no-cache update && apk add curl file
+LABEL maintainer "Moncho"
 
-# install dry
-RUN curl -sSf https://moncho.github.io/dry/dryup.sh | sh
-RUN chmod 755 /usr/local/bin/dry
-CMD sleep 1;/usr/local/bin/dry
+RUN set -x && \
+    apk update && \
+    apk upgrade && \
+    apk add curl file && \
+    curl https://moncho.github.io/dry/dryup.sh | sh && \
+    apk del curl file && \
+    rm -rf /var/cache/apk/* && \
+    chmod 755 /usr/local/bin/dry
+
+CMD ["sleep 1;/usr/local/bin/dry"]

--- a/dryup.sh
+++ b/dryup.sh
@@ -224,7 +224,13 @@ get_architecture() {
             ;;
 
 	*)
-            err "unknown CPU type: $CFG_CPUTYPE"
+            _isarm=$(echo $_cputype|awk '{print substr($0,0,4)}')
+            echo $_isarm
+            if [ "$_isarm" = "arm" ]; then
+               local _cputype=arm
+            else
+               err "unknown CPU type: $CFG_CPUTYPE"
+            fi
 
     esac
 

--- a/dryup.sh
+++ b/dryup.sh
@@ -178,6 +178,7 @@ get_architecture() {
 
     local _ostype="$(uname -s)"
     local _cputype="$(uname -m)"
+    local _isarm
 
     verbose_say "uname -s reports: $_ostype"
     verbose_say "uname -m reports: $_cputype"


### PR DESCRIPTION
Hi,

Here is my PR, with 2 updates files: 

- Dockerfile dry image goes from 45Mb down to 20Mb
- dryup.sh to handle ARM detection and download


BR
Vincent