### PR TITLE
Add chmod as installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ Keybinding           | Description
 
 The easiest way to install the latest binaries for Linux and Mac is to run this in your shell:
 
-```curl -sSf https://moncho.github.io/dry/dryup.sh | sudo sh```
+```sh
+curl -sSf https://moncho.github.io/dry/dryup.sh | sudo sh
+sudo chmod 755 /usr/local/bin/dry
+```
 
 ### Binaries
 


### PR DESCRIPTION
The second step (`chmod`) is mentioned on the web and also after the `dryup.sh` script execution. As it is a legitimate installation step, it should be mentioned in the readme too.