### PR TITLE
ARM architecture as a case statement

### DIFF
--- a/dryup.sh
+++ b/dryup.sh
@@ -223,7 +223,7 @@ get_architecture() {
 	x86_64 | x86-64 | x64 | amd64)
             local _cputype=amd64
             ;;
-  arm*)
+  	arm*)
             local _cputype=arm
             ;;
 	*)

--- a/dryup.sh
+++ b/dryup.sh
@@ -223,15 +223,11 @@ get_architecture() {
 	x86_64 | x86-64 | x64 | amd64)
             local _cputype=amd64
             ;;
-
+  arm*)
+            local _cputype=arm
+            ;;
 	*)
-            _isarm=$(echo $_cputype|awk '{print substr($0,0,3)}')
-            echo $_isarm
-            if [ "$_isarm" = "arm" ]; then
-               local _cputype=arm
-            else
                err "unknown CPU type: $CFG_CPUTYPE"
-            fi
 
     esac
 

--- a/dryup.sh
+++ b/dryup.sh
@@ -225,7 +225,7 @@ get_architecture() {
             ;;
 
 	*)
-            _isarm=$(echo $_cputype|awk '{print substr($0,0,4)}')
+            _isarm=$(echo $_cputype|awk '{print substr($0,0,3)}')
             echo $_isarm
             if [ "$_isarm" = "arm" ]; then
                local _cputype=arm


### PR DESCRIPTION
On different systems  `_isarm=$(echo $_cputype|awk '{print substr($0,0,4)}')` provides a different results, on RPi it's working with expected results, but on Odroid-XU4 the output is `armv` which is not matched in current version of the script, thus resulting in error:

Debian 8 Odroid-XU4
```
# uname -a
Linux nas 4.9.61-odroidxu4 #2 SMP PREEMPT Wed Nov 22 16:34:23 CET 2017 armv7l GNU/Linux
# curl -sSf https://moncho.github.io/dry/dryup.sh | sudo sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    10  100    10    0     0     33      0 --:--:-- --:--:-- --:--:--    33
armv
sh: 233: CFG_CPUTYPE: parameter not set

```
Raspberry Pi

```
# uname -a
Linux retropie 4.9.26v7-aufs #1 SMP Tue May 9 20:14:03 CEST 2017 armv7l GNU/Linux
# curl -sSf https://moncho.github.io/dry/dryup.sh | sudo sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    10  100    10    0     0     38      0 --:--:-- --:--:-- --:--:--    38
dryup: downloading dry binary
######################################################################## 100.0%
dryup: Moving dry binary to its destination
dryup: dry binary was copied to /usr/local/bin, now you should 'sudo chmod 755 /usr/local/bin/dry'
```