### PR TITLE
Add Vim- and Emacs-style keybindings for scroll up/down

### DIFF
--- a/app/events.go
+++ b/app/events.go
@@ -28,14 +28,9 @@ func (b *baseEventHandler) handle(event termbox.Event, f func(eventHandler)) {
 	cursor := screen.Cursor
 	refresh := true
 	switch event.Key {
-	case termbox.KeyArrowUp: //cursor up
-		cursor.ScrollCursorUp()
 	case termbox.KeyArrowUp, termbox.KeyCtrlP: //cursor up
 		cursor.ScrollCursorUp()
-		cursor.ScrollCursorUp()
 	case termbox.KeyArrowDown, termbox.KeyCtrlN: // cursor down
-		cursor.ScrollCursorDown()
-	case termbox.KeyCtrlN: // cursor down
 		cursor.ScrollCursorDown()
 	case termbox.KeyF8: // disk usage
 		f(viewsToHandlers[DiskUsage])

--- a/app/events.go
+++ b/app/events.go
@@ -30,7 +30,11 @@ func (b *baseEventHandler) handle(event termbox.Event, f func(eventHandler)) {
 	switch event.Key {
 	case termbox.KeyArrowUp: //cursor up
 		cursor.ScrollCursorUp()
+	case termbox.KeyCtrlP: //cursor up
+		cursor.ScrollCursorUp()
 	case termbox.KeyArrowDown: // cursor down
+		cursor.ScrollCursorDown()
+	case termbox.KeyCtrlN: // cursor down
 		cursor.ScrollCursorDown()
 	case termbox.KeyF8: // disk usage
 		f(viewsToHandlers[DiskUsage])
@@ -77,6 +81,10 @@ func (b *baseEventHandler) handle(event termbox.Event, f func(eventHandler)) {
 		}
 	}
 	switch event.Ch {
+	case 'k':
+		cursor.ScrollCursorUp()
+	case 'j':
+		cursor.ScrollCursorDown()
 	case '?', 'h', 'H': //help
 		refresh = false
 

--- a/app/events.go
+++ b/app/events.go
@@ -33,7 +33,7 @@ func (b *baseEventHandler) handle(event termbox.Event, f func(eventHandler)) {
 	case termbox.KeyArrowUp, termbox.KeyCtrlP: //cursor up
 		cursor.ScrollCursorUp()
 		cursor.ScrollCursorUp()
-	case termbox.KeyArrowDown: // cursor down
+	case termbox.KeyArrowDown, termbox.KeyCtrlN: // cursor down
 		cursor.ScrollCursorDown()
 	case termbox.KeyCtrlN: // cursor down
 		cursor.ScrollCursorDown()

--- a/app/events.go
+++ b/app/events.go
@@ -30,7 +30,8 @@ func (b *baseEventHandler) handle(event termbox.Event, f func(eventHandler)) {
 	switch event.Key {
 	case termbox.KeyArrowUp: //cursor up
 		cursor.ScrollCursorUp()
-	case termbox.KeyCtrlP: //cursor up
+	case termbox.KeyArrowUp, termbox.KeyCtrlP: //cursor up
+		cursor.ScrollCursorUp()
 		cursor.ScrollCursorUp()
 	case termbox.KeyArrowDown: // cursor down
 		cursor.ScrollCursorDown()


### PR DESCRIPTION
I think this addresses https://github.com/moncho/dry/issues/15 and also throws in Emacs-style bindings.