### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -236,7 +236,7 @@ func (daemon *DockerDaemon) Ok() (bool, error) {
 	return daemon.err == nil, daemon.err
 }
 
-//OpenChannel creates a channel with the runtime stats of the given container
+//StatsChannel creates a channel with the runtime stats of the given container
 func (daemon *DockerDaemon) StatsChannel(container *Container) (*StatsChannel, error) {
 	return newStatsChannel(daemon.version, daemon.client, container)
 }


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?