### PR TITLE
Update help_texts.go quit keybind

### DIFF
--- a/app/help_texts.go
+++ b/app/help_texts.go
@@ -33,7 +33,7 @@ Visit <blue>http://moncho.github.io/dry/</> for more information.
 	<white>m</>         Show container monitor mode
 	<white>h</>         Shows this help screen
 	<white>Ctrl+c</>    Quits <white>dry</> immediately
-	<white>q</>         Quits <white>dry</>
+	<white>Q</>         Quits <white>dry</>
 	<white>esc</>       Goes back to the main screen
 
 <yellow>Global list keybinds</>	


### PR DESCRIPTION
Quit keybind should be uppercase in help text