### PR TITLE
for range needs to be compilable with go 1.3.3

### DIFF
--- a/app/loop.go
+++ b/app/loop.go
@@ -39,7 +39,7 @@ func RenderLoop(dry *Dry, screen *ui.Screen) {
 		wg.Add(1)
 		defer wg.Done()
 
-		for range renderChan {
+		for _ = range renderChan {
 			if !screen.Closing() {
 				screen.Clear()
 				render(dry, screen)

--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -4,3 +4,14 @@ tenets:
   - import: codelingo/effective-go/underscores-in-name
   - import: codelingo/effective-go/single-method-interface-name
   - import: codelingo/effective-go/avoid-annotations-in-comments
+  - name: for-range-go-1-3-3
+    flows:
+      codelingo/review:
+        comment: for range needs to be compilable with go 1.3.3
+    query: |
+      import codelingo/ast/go
+      
+      @review comment
+      go.range_stmt(depth = any):
+        tok != "="
+        tok != ":="

--- a/ui/less.go
+++ b/ui/less.go
@@ -119,7 +119,7 @@ func (less *Less) Focus(events <-chan termbox.Event) error {
 		}
 	}(&inputMode)
 
-	for range less.refresh {
+	for _ = range less.refresh {
 		//If input is being read, refresh events are ignore
 		//the only UI changes are happening on the input bar
 		//and are done by the InputBox


### PR DESCRIPTION
Hi @moncho 

This PR fixes the backwards compatibility of the `for rang` statements in go 1.3.3. [A previous PR](https://github.com/moncho/dry/pull/11) addressed some instances of the `for range` but not all. 

We (@codelingo) like to check up on our open source users as much as possible, so we wrote [a tenet](https://github.com/leilaes/dry/blob/development/codelingo.yaml#L7) that found this issue, and it will comment on any pull request that introduces the issue again.

Let me know if this is helpful, or if you want help customising this tenet or writing your own!