### PR TITLE
Fixed import order using goimports

### DIFF
--- a/app/misc.go
+++ b/app/misc.go
@@ -1,10 +1,11 @@
 package app
 
 import (
+	"strings"
+
 	"github.com/moncho/dry/appui"
 	"github.com/moncho/dry/ui"
 	termbox "github.com/nsf/termbox-go"
-	"strings"
 )
 
 func logsPrompt() *appui.Prompt {

--- a/appui/header.go
+++ b/appui/header.go
@@ -2,8 +2,9 @@ package appui
 
 import (
 	"fmt"
-	"github.com/moncho/dry/docker"
 	"strings"
+
+	"github.com/moncho/dry/docker"
 
 	gizaktermui "github.com/gizak/termui"
 	"github.com/moncho/dry/ui/termui"

--- a/appui/header_test.go
+++ b/appui/header_test.go
@@ -1,9 +1,10 @@
 package appui
 
 import (
-	"github.com/moncho/dry/ui/termui"
 	"strings"
 	"testing"
+
+	"github.com/moncho/dry/ui/termui"
 )
 
 func TestWidgetHeader(t *testing.T) {

--- a/appui/images.go
+++ b/appui/images.go
@@ -1,11 +1,12 @@
 package appui
 
 import (
-	"github.com/docker/docker/api/types"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/docker/docker/api/types"
 
 	gizaktermui "github.com/gizak/termui"
 	"github.com/moncho/dry/docker"

--- a/appui/row_filter_test.go
+++ b/appui/row_filter_test.go
@@ -1,9 +1,10 @@
 package appui
 
 import (
+	"testing"
+
 	gizak "github.com/gizak/termui"
 	"github.com/moncho/dry/ui/termui"
-	"testing"
 )
 
 func TestRowFilter_ByPattern(t *testing.T) {

--- a/docker/daemon_test.go
+++ b/docker/daemon_test.go
@@ -3,9 +3,10 @@ package docker
 import (
 	"context"
 	"errors"
-	"github.com/docker/docker/api/types/filters"
 	"testing"
 	"time"
+
+	"github.com/docker/docker/api/types/filters"
 
 	dockerTypes "github.com/docker/docker/api/types"
 	dockerAPI "github.com/docker/docker/client"

--- a/ui/termui/stringer.go
+++ b/ui/termui/stringer.go
@@ -1,10 +1,11 @@
 package termui
 
 import (
-	"github.com/gizak/termui"
 	"image"
 	"sort"
 	"strings"
+
+	"github.com/gizak/termui"
 )
 
 type bufferer interface {


### PR DESCRIPTION
Looks a bit neater and really just prevents future merge conflicts.