### PR TITLE
Add to waitgroup before starting goroutine

### DIFF
--- a/app/loop.go
+++ b/app/loop.go
@@ -47,8 +47,8 @@ func RenderLoop(dry *Dry) {
 	dryOutputChan := dry.OuputChannel()
 
 	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		defer wg.Done()
 
 		for range renderChan {


### PR DESCRIPTION
This prevents a race condition where we potentially check the WaitGroup before
the goroutine even had a chance to start.