### PR TITLE
Fix problem when showing logs of containers using a non-default logging driver

### DIFF
--- a/app/cmenu_events.go
+++ b/app/cmenu_events.go
@@ -191,6 +191,7 @@ func (h *cMenuEventHandler) handleCommand(id string, command docker.Command, f f
 						refreshScreen()
 					})
 			} else {
+				f(h)
 				h.dry.message("Error showing container logs: " + err.Error())
 			}
 		}()

--- a/app/container_events.go
+++ b/app/container_events.go
@@ -547,7 +547,6 @@ func (h *containersScreenEventHandler) showLogs(id string, withTimestamp bool, f
 		} else {
 			f(h)
 			h.dry.message("Error showing container logs: " + err.Error())
-
 		}
 	}()
 }


### PR DESCRIPTION
refs #118 