### PR TITLE
Move Docker build workflow to using the official Docker build actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,25 +1,37 @@
 name: Build & Push Docker image
+
 on:
   push:
-    branches:
-      - master
-    paths:
-      - 'APPVERSION'
+    # branches:
+    #   - master
+    # paths:
+    #   - 'APPVERSION'
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
         uses: actions/checkout@v2
-      - name: install buildx
-        id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1.0.1
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v1.0.3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1 
         with:
-          version: latest
-      - name: login to docker hub
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin
-      - name: build image
-        run: |
-        docker buildx build - push \
-          --tag moncho/dry:latest \
-          --platform linux/amd64,linux/arm/v7,linux/arm64 .
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.1.0
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: florianpiesche/dry:latest
+          platforms: linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64
+          push: true
+  

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          tags: florianpiesche/dry:latest
+          tags: moncho/dry:latest
           platforms: linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/amd64
           push: true
   

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,12 @@ name: Build & Push Docker image
 
 on:
   push:
-    # branches:
-    #   - master
-    # paths:
-    #   - 'APPVERSION'
+    branches:
+      - master
+    paths:
+      - 'APPVERSION'
+  # Allow manual runs.
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Also build for armv6 because why not.

The only notable caveat here is that this setup uses Docker Hub access tokens rather than passwords - though this is likely more secure than keeping your Docker password in a repo secret nonetheless.