### PR TITLE
Display IPv6 addresses in container details and networks views

### DIFF
--- a/appui/container.go
+++ b/appui/container.go
@@ -30,14 +30,20 @@ func NewContainerInfo(container *docker.Container) (string, int) {
 	}
 	var networkNames []string
 	var networkIps []string
+	var networkIpv6s []string
 	for k, v := range container.Container.NetworkSettings.Networks {
 		networkNames = append(networkNames, ui.Blue("Network Name: "))
 		networkNames = append(networkNames, ui.Yellow(k))
 		networkIps = append(networkIps, ui.Blue("\tIP Address:"))
 		networkIps = append(networkIps, ui.Yellow(v.IPAddress))
+		if v.GlobalIPv6Address != "" {
+			networkIpv6s = append(networkIpv6s, ui.Blue("\tIPv6 Address:"))
+			networkIpv6s = append(networkIpv6s, ui.Yellow(v.GlobalIPv6Address + "/" + strconv.Itoa(v.GlobalIPv6PrefixLen)))
+		}
 	}
 	data = append(data, networkNames)
 	data = append(data, networkIps)
+	data = append(data, networkIpv6s)
 
 	data = append(data, []string{ui.Blue("Labels"), ui.Yellow(
 		strconv.Itoa(len(container.Labels)))})

--- a/appui/networks.go
+++ b/appui/networks.go
@@ -20,8 +20,8 @@ var networkTableHeaders = []SortableColumnHeader{
 	{`CONTAINERS`, SortMode(docker.SortNetworksByContainerCount)},
 	{`SERVICES`, SortMode(docker.SortNetworksByServiceCount)},
 	{`SCOPE`, SortMode(docker.NoSortNetworks)},
-	{`SUBNET`, SortMode(docker.SortNetworksBySubnet)},
-	{`GATEWAY`, SortMode(docker.NoSortNetworks)},
+	{`SUBNETS`, SortMode(docker.SortNetworksBySubnet)},
+	{`GATEWAYS`, SortMode(docker.NoSortNetworks)},
 }
 
 // DockerNetworksWidget knows how render a container list

--- a/docker/formatter/network_formatter.go
+++ b/docker/formatter/network_formatter.go
@@ -1,6 +1,7 @@
 package formatter
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 
@@ -15,8 +16,8 @@ const (
 	numberOfContainers = "NUMBER OF CONTAINERS"
 	numberOfServices   = "NUMBER OF SERVICES"
 	scope              = "SCOPE"
-	subnet             = "SUBNET"
-	gateway            = "GATEWAY"
+	subnet             = "SUBNETS"
+	gateway            = "GATEWAYS"
 )
 
 // NetworkFormatter knows how to pretty-print the information of an network
@@ -86,17 +87,31 @@ func (formatter *NetworkFormatter) Scope() string {
 // Subnet prettifies the network subnet
 func (formatter *NetworkFormatter) Subnet() string {
 	formatter.addHeader(subnet)
-	if len(formatter.network.IPAM.Config) > 0 {
-		return formatter.network.IPAM.Config[0].Subnet
+	var subnets []string
+	for _, config := range formatter.network.IPAM.Config {
+		if config.Subnet != "" {
+			subnets = append(subnets, config.Subnet)
+		}
 	}
-	return ""
+	// display IPv4 subnets first
+	sort.Slice(subnets, func(i, j int) bool {
+		return strings.Contains(subnets[i], ".")
+	})
+	return strings.Join(subnets, ", ")
 }
 
 // Gateway prettifies the network gateway
 func (formatter *NetworkFormatter) Gateway() string {
 	formatter.addHeader(gateway)
-	if len(formatter.network.IPAM.Config) > 0 {
-		return formatter.network.IPAM.Config[0].Gateway
+	var gateways []string
+	for _, config := range formatter.network.IPAM.Config {
+		if config.Gateway != "" {
+			gateways = append(gateways, config.Gateway)
+		}
 	}
-	return ""
+	// display IPv4 gateways first
+	sort.Slice(gateways, func(i, j int) bool {
+		return strings.Contains(gateways[i], ".")
+	})
+	return strings.Join(gateways, ", ")
 }


### PR DESCRIPTION
This PR has two parts:

- the Container Details view now shows a containers IPv6 address of each network it is connected to, if present
![container_details](https://github.com/moncho/dry/assets/425180/ccef33a2-2381-4c74-89c3-df46c8251151)


- the Network view now shows all subnets with their gateways within a network (thus including IPv6 subnets)
![networks](https://github.com/moncho/dry/assets/425180/51b84f2b-c246-40d7-a8df-346c3b53e960)

I did not find other relevant places to add v6 support, but if you show me, I'd be happy to add support there too.
