### PR TITLE
chore: enable automatic Docker API version negotiation

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -195,7 +195,7 @@ func (daemon *DockerDaemon) Kill(id string) error {
 
 // Logs shows the logs of the container with the given id
 func (daemon *DockerDaemon) Logs(id string, since string, withTimeStamps bool) (io.ReadCloser, error) {
-	options := dockerTypes.ContainerLogsOptions{
+	options := container.LogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
 		Timestamps: withTimeStamps,

--- a/docker/docker_environment.go
+++ b/docker/docker_environment.go
@@ -2,6 +2,8 @@ package docker
 
 import (
 	"os"
+
+	"github.com/docker/docker/api"
 )
 
 // Env holds Docker-related environment variables
@@ -16,8 +18,7 @@ type Env struct {
 func NewEnv() Env {
 	version := os.Getenv("DOCKER_API_VERSION")
 	if version == "" {
-		version = "1.37"
-		//version = api.DefaultVersion
+		version = api.DefaultVersion
 	}
 	return Env{DockerAPIVersion: version}
 }


### PR DESCRIPTION

From the Docker client API: "With this option enabled, the client automatically negotiates the API to use when making requests". Hopefully this fixes recurring problems with older versions of Docker. 