### PR TITLE
fix: handle unchecked error return values (errcheck)

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -36,9 +36,9 @@ func demuxDockerStream(raw io.ReadCloser) io.ReadCloser {
 		if err != nil {
 			pw.CloseWithError(err)
 		} else {
-			pw.Close()
+			_ = pw.Close()
 		}
-		raw.Close()
+		_ = raw.Close()
 	}()
 	return &demuxedReadCloser{
 		Reader: pr,
@@ -62,7 +62,7 @@ func readLogStreamCmd(reader io.ReadCloser) tea.Cmd {
 			}
 		}
 		if err != nil {
-			reader.Close()
+			_ = reader.Close()
 			return streamClosedMsg{}
 		}
 		return streamClosedMsg{}

--- a/app/model.go
+++ b/app/model.go
@@ -336,7 +336,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// Overlay was closed, clean up the reader
 		if msg.reader != nil {
-			msg.reader.Close()
+			_ = msg.reader.Close()
 		}
 		return m, nil
 
@@ -348,7 +348,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.overlay = overlayNone
 		m.eventsLive = false
 		if m.streamReader != nil {
-			m.streamReader.Close()
+			_ = m.streamReader.Close()
 			m.streamReader = nil
 		}
 		return m, nil
@@ -424,7 +424,7 @@ func (m model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+c", "Q":
 		m.monitor.StopAll()
 		if m.streamReader != nil {
-			m.streamReader.Close()
+			_ = m.streamReader.Close()
 			m.streamReader = nil
 		}
 		if m.eventsCancel != nil {

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -540,7 +540,7 @@ func (daemon *DockerDaemon) init() error {
 	GlobalRegistry.Register(
 		ContainerSource,
 		func(ctx context.Context, message dockerEvents.Message) {
-			daemon.refreshAndWait()
+			_ = daemon.refreshAndWait()
 		})
 	return nil
 }

--- a/docker/formatter/context.go
+++ b/docker/formatter/context.go
@@ -71,13 +71,13 @@ func (c *Context) postFormat(tmpl *template.Template, subContext subContext) {
 	if c.Format.IsTable() {
 		t := tabwriter.NewWriter(c.Output, 20, 1, 3, ' ', 0)
 		buffer := bytes.NewBufferString("")
-		tmpl.Funcs(templates.HeaderFunctions).Execute(buffer, subContext.FullHeader())
-		buffer.WriteTo(t)
-		t.Write([]byte("\n"))
-		c.buffer.WriteTo(t)
+		_ = tmpl.Funcs(templates.HeaderFunctions).Execute(buffer, subContext.FullHeader())
+		_, _ = buffer.WriteTo(t)
+		_, _ = t.Write([]byte("\n"))
+		_, _ = c.buffer.WriteTo(t)
 		t.Flush()
 	} else {
-		c.buffer.WriteTo(c.Output)
+		_, _ = c.buffer.WriteTo(c.Output)
 	}
 }
 


### PR DESCRIPTION

Explicitly discard error return values from Close, Write, WriteTo, and Execute calls where errors cannot be meaningfully handled.