### PR TITLE
fix: correct table viewport height and cursor reset on first draw

### DIFF
--- a/app/model.go
+++ b/app/model.go
@@ -44,9 +44,9 @@ type model struct {
 	ready        bool
 
 	// Docker
-	daemon     docker.ContainerDaemon
-	config     Config
-	swarmMode  bool
+	daemon       docker.ContainerDaemon
+	config       Config
+	swarmMode    bool
 	eventsChan   <-chan events.Message
 	eventsCancel context.CancelFunc
 

--- a/app/render_test.go
+++ b/app/render_test.go
@@ -1,0 +1,124 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/moncho/dry/appui"
+	"github.com/moncho/dry/docker"
+	"github.com/moncho/dry/mocks"
+)
+
+func TestRenderMainScreen_LineCount(t *testing.T) {
+	appui.InitStyles()
+	m := newTestModel()
+	m.header = appui.NewHeaderModel(m.daemon, m.width)
+
+	containers := m.daemon.Containers(nil, docker.SortByContainerID)
+
+	result, _ := m.Update(containersLoadedMsg{containers: containers})
+	m = result.(model)
+
+	hdrLines := strings.Split(m.header.View(), "\n")
+	sepLines := strings.Split(m.header.SeparatorLine(""), "\n")
+	t.Logf("Header lines: %d, Separator lines: %d", len(hdrLines), len(sepLines))
+
+	contentLines := strings.Split(m.containers.View(), "\n")
+	t.Logf("Content lines: %d (expected contentHeight=%d)", len(contentLines), m.contentHeight())
+
+	v := m.renderMainScreen()
+	lines := strings.Split(v, "\n")
+	t.Logf("Terminal: %dx%d, Total lines: %d (expected %d)", m.width, m.height, len(lines), m.height)
+
+	dataRows := 0
+	for _, l := range contentLines {
+		if strings.Contains(l, "▶") || strings.Contains(l, "■") {
+			dataRows++
+		}
+	}
+	t.Logf("Data rows: %d", dataRows)
+
+	if len(lines) != m.height {
+		t.Errorf("Expected %d lines, got %d", m.height, len(lines))
+	}
+
+	result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = result.(model)
+	contentLines2 := strings.Split(m.containers.View(), "\n")
+	dataRows2 := 0
+	for _, l := range contentLines2 {
+		if strings.Contains(l, "▶") || strings.Contains(l, "■") {
+			dataRows2++
+		}
+	}
+	t.Logf("Data rows after nav: %d", dataRows2)
+	if dataRows != dataRows2 {
+		t.Errorf("Data row count changed: %d -> %d", dataRows, dataRows2)
+	}
+}
+
+func TestRenderMainScreen_SmallTerminal(t *testing.T) {
+	// Simulate a small terminal where rows exceed viewport capacity
+	appui.InitStyles()
+	m := NewModel(Config{})
+	m.width = 120
+	m.height = 25 // small terminal
+	m.daemon = &mocks.DockerDaemonMock{}
+	m.ready = true
+	m.containers.SetDaemon(m.daemon)
+	m.header = appui.NewHeaderModel(m.daemon, m.width)
+
+	ch := m.contentHeight()
+	m.containers.SetSize(m.width, ch)
+
+	// 20 containers > viewport capacity
+	containers := m.daemon.Containers(nil, docker.SortByContainerID)
+	result, _ := m.Update(containersLoadedMsg{containers: containers})
+	m = result.(model)
+
+	contentLines := strings.Split(m.containers.View(), "\n")
+	dataRows := 0
+	for _, l := range contentLines {
+		if strings.Contains(l, "▶") || strings.Contains(l, "■") {
+			dataRows++
+		}
+	}
+	// Table height = contentHeight - 1 (widget header)
+	// Visible data = tableHeight - 1 (table header)
+	expectedDataRows := ch -
+		1 - // widget header
+		1 - // blank line
+		1 - // table header
+		1 // blank line after the table
+	if dataRows < len(containers) {
+		// More containers than viewport - should show viewport's worth
+		t.Logf("Terminal %dx%d, contentHeight=%d, tableH=%d", m.width, m.height, ch, ch-1)
+		t.Logf("Visible data rows: %d (expected %d)", dataRows, expectedDataRows)
+		if dataRows != expectedDataRows {
+			t.Errorf("Expected %d visible data rows, got %d", expectedDataRows, dataRows)
+		}
+	}
+
+	// Navigate and check
+	result, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+	m = result.(model)
+	contentLines2 := strings.Split(m.containers.View(), "\n")
+	dataRows2 := 0
+	for _, l := range contentLines2 {
+		if strings.Contains(l, "▶") || strings.Contains(l, "■") {
+			dataRows2++
+		}
+	}
+	t.Logf("Data rows after nav: %d", dataRows2)
+	if dataRows != dataRows2 {
+		t.Errorf("Data row count changed after nav: %d -> %d", dataRows, dataRows2)
+	}
+
+	v := m.renderMainScreen()
+	totalLines := len(strings.Split(v, "\n"))
+	t.Logf("Total screen lines: %d (expected %d)", totalLines, m.height)
+	if totalLines != m.height {
+		t.Errorf("Expected %d total lines, got %d", m.height, totalLines)
+	}
+}

--- a/appui/table_model.go
+++ b/appui/table_model.go
@@ -87,14 +87,16 @@ func (m *TableModel) SetRows(rows []TableRow) {
 	m.syncInner()
 }
 
-// SetSize updates the table dimensions.
+// SetSize updates the table dimensions. Table height is reduced
+// by 1 to leave space for the blank line after the table.
 func (m *TableModel) SetSize(w, h int) {
 	m.width = w
 	m.height = h
 	m.calculateColumnWidths()
-	m.inner.SetWidth(w)
-	m.inner.SetHeight(h)
 	m.syncInnerColumns()
+	m.inner.SetWidth(w)
+	// -1 for blank line after the table
+	m.inner.SetHeight(h - 1)
 }
 
 // Width returns the table's current width.
@@ -206,7 +208,10 @@ func (m TableModel) View() string {
 
 func (m *TableModel) syncInner() {
 	m.inner.SetRows(m.toBubblesRows())
-	if cursor := m.inner.Cursor(); cursor >= len(m.filtered) && len(m.filtered) > 0 {
+	cursor := m.inner.Cursor()
+	if cursor < 0 && len(m.filtered) > 0 {
+		m.inner.SetCursor(0)
+	} else if cursor >= len(m.filtered) && len(m.filtered) > 0 {
 		m.inner.SetCursor(len(m.filtered) - 1)
 	}
 }

--- a/mocks/docker_daemon.go
+++ b/mocks/docker_daemon.go
@@ -27,16 +27,15 @@ func (_m *DockerDaemonMock) ContainerByID(id string) *drydocker.Container {
 }
 
 // Containers mock
-func (_m *DockerDaemonMock) Containers(filters []drydocker.ContainerFilter, mode drydocker.SortMode) []*drydocker.Container {
-
+func (_m *DockerDaemonMock) Containers(filters []drydocker.ContainerFilter, _ drydocker.SortMode) []*drydocker.Container {
 	var containers []*drydocker.Container
-	for index := 0; index < 10; index++ {
+	for index := range 10 {
 		containers = append(containers, &drydocker.Container{
 			Summary: container.Summary{ID: strconv.Itoa(index), Names: []string{"Name"},
 				Status: "Up and running"},
 		})
 	}
-	for index := 0; index < 10; index++ {
+	for index := range 10 {
 		containers = append(containers, &drydocker.Container{
 			Summary: container.Summary{ID: strconv.Itoa(index), Names: []string{"Name"},
 				Status: "Never worked"},


### PR DESCRIPTION

Fix table first-draw issue by reserving space for the blank line after the table, syncing columns before setting dimensions, and resetting the cursor when it goes negative after empty-to-populated row transitions.