### PR TITLE
feat: add Compose view with inline services, ports, health, and logs

### DIFF
--- a/app/help_texts.go
+++ b/app/help_texts.go
@@ -28,6 +28,7 @@ Visit <blue>http://moncho.github.io/dry/</> for more information.
 	<white>5</>         To node list (in Swarm mode)
 	<white>6</>         To service list (in Swarm mode)
 	<white>7</>         To stack list (in Swarm mode)
+	<white>8</>         To compose projects list
 	<white>m</>         Show container monitor mode
 	<white>h</>         Shows this help screen
 	<white>Ctrl+c</>    Quits <white>dry</> immediately
@@ -74,7 +75,18 @@ Visit <blue>http://moncho.github.io/dry/</> for more information.
 <yellow>Stack list keybinds</>
 	<white>Enter</>     Shows the list of tasks of the selected stack
 	<white>Ctrl+R</>    Removes the selected stack
-	
+
+<yellow>Compose Projects</>
+	<white>Enter</>     Shows the services of the selected project
+	<white>F1</>        Sorts the list
+	<white>F5</>        Refreshes the list
+	<white>%</>         Filters the list
+
+<yellow>Compose Services</>
+	<white>Esc</>       Back to projects
+	<white>F1</>        Sorts the list
+	<white>%</>         Filters the list
+
 <yellow>Move around in lists</>
 	<white>ArrowUp</>   Moves the cursor one line up
 	<white>ArrowDown</> Moves the cursor one line down

--- a/app/keys.go
+++ b/app/keys.go
@@ -12,6 +12,7 @@ type globalKeyMap struct {
 	Nodes        key.Binding
 	Services     key.Binding
 	Stacks       key.Binding
+	Compose      key.Binding
 	Monitor      key.Binding
 	ToggleHeader key.Binding
 	DiskUsage    key.Binding
@@ -57,6 +58,10 @@ var globalKeys = globalKeyMap{
 		key.WithKeys("7"),
 		key.WithHelp("7", "stacks"),
 	),
+	Compose: key.NewBinding(
+		key.WithKeys("8"),
+		key.WithHelp("8", "compose"),
+	),
 	Monitor: key.NewBinding(
 		key.WithKeys("m", "M"),
 		key.WithHelp("m", "monitor"),
@@ -90,11 +95,11 @@ var globalKeys = globalKeyMap{
 // --- containers (Main) ------------------------------------------------
 
 type containerKeyMap struct {
-	Help, Quit                                       key.Binding
-	Sort, AllRunning, Refresh, Filter                key.Binding
-	Monitor, Images, Nets, Vols, Nodes, Svcs, Stacks key.Binding
-	Commands                                         key.Binding
-	Logs, Stats, Rm, RmStopped, Kill, Restart, Stop  key.Binding
+	Help, Quit                                                key.Binding
+	Sort, AllRunning, Refresh, Filter                         key.Binding
+	Monitor, Images, Nets, Vols, Nodes, Svcs, Stacks, Compose key.Binding
+	Commands                                                  key.Binding
+	Logs, Stats, Rm, RmStopped, Kill, Restart, Stop           key.Binding
 }
 
 var containerKeys = containerKeyMap{
@@ -111,6 +116,7 @@ var containerKeys = containerKeyMap{
 	Nodes:      key.NewBinding(key.WithKeys("5"), key.WithHelp("5", "nodes")),
 	Svcs:       key.NewBinding(key.WithKeys("6"), key.WithHelp("6", "svcs")),
 	Stacks:     key.NewBinding(key.WithKeys("7"), key.WithHelp("7", "stacks")),
+	Compose:    key.NewBinding(key.WithKeys("8"), key.WithHelp("8", "compose")),
 	Commands:   key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "commands")),
 	Logs:       key.NewBinding(key.WithKeys("l"), key.WithHelp("l", "logs")),
 	Stats:      key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "stats")),
@@ -125,7 +131,7 @@ func (k containerKeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.Help, k.Quit,
 		k.Sort, k.AllRunning, k.Refresh, k.Filter,
-		k.Monitor, k.Images, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks,
+		k.Monitor, k.Images, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks, k.Compose,
 		k.Commands, k.Logs, k.Stats,
 		k.Rm, k.RmStopped, k.Kill, k.Restart, k.Stop,
 	}
@@ -136,9 +142,9 @@ func (k containerKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{k.S
 // --- monitor ----------------------------------------------------------
 
 type monitorKeyMap struct {
-	Help, Quit                                                   key.Binding
-	Sort                                                         key.Binding
-	Monitor, Containers, Images, Nets, Vols, Nodes, Svcs, Stacks key.Binding
+	Help, Quit                                                            key.Binding
+	Sort                                                                  key.Binding
+	Monitor, Containers, Images, Nets, Vols, Nodes, Svcs, Stacks, Compose key.Binding
 }
 
 var monitorKeys = monitorKeyMap{
@@ -153,12 +159,13 @@ var monitorKeys = monitorKeyMap{
 	Nodes:      key.NewBinding(key.WithKeys("5"), key.WithHelp("5", "nodes")),
 	Svcs:       key.NewBinding(key.WithKeys("6"), key.WithHelp("6", "svcs")),
 	Stacks:     key.NewBinding(key.WithKeys("7"), key.WithHelp("7", "stacks")),
+	Compose:    key.NewBinding(key.WithKeys("8"), key.WithHelp("8", "compose")),
 }
 
 func (k monitorKeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.Help, k.Quit, k.Sort,
-		k.Monitor, k.Containers, k.Images, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks,
+		k.Monitor, k.Containers, k.Images, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks, k.Compose,
 	}
 }
 
@@ -167,11 +174,11 @@ func (k monitorKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{k.Sho
 // --- images -----------------------------------------------------------
 
 type imagesKeyMap struct {
-	Help, Quit                                  key.Binding
-	Sort, Refresh, Filter                       key.Binding
-	Containers, Nets, Vols, Nodes, Svcs, Stacks key.Binding
-	Inspect                                     key.Binding
-	RmDangling, Rm, ForceRm, RmUnused, History  key.Binding
+	Help, Quit                                           key.Binding
+	Sort, Refresh, Filter                                key.Binding
+	Containers, Nets, Vols, Nodes, Svcs, Stacks, Compose key.Binding
+	Inspect                                              key.Binding
+	RmDangling, Rm, ForceRm, RmUnused, History           key.Binding
 }
 
 var imagesKeys = imagesKeyMap{
@@ -186,6 +193,7 @@ var imagesKeys = imagesKeyMap{
 	Nodes:      key.NewBinding(key.WithKeys("5"), key.WithHelp("5", "nodes")),
 	Svcs:       key.NewBinding(key.WithKeys("6"), key.WithHelp("6", "svcs")),
 	Stacks:     key.NewBinding(key.WithKeys("7"), key.WithHelp("7", "stacks")),
+	Compose:    key.NewBinding(key.WithKeys("8"), key.WithHelp("8", "compose")),
 	Inspect:    key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "inspect")),
 	RmDangling: key.NewBinding(key.WithKeys("ctrl+d"), key.WithHelp("^d", "rm dangling")),
 	Rm:         key.NewBinding(key.WithKeys("ctrl+e"), key.WithHelp("^e", "rm")),
@@ -197,7 +205,7 @@ var imagesKeys = imagesKeyMap{
 func (k imagesKeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.Help, k.Quit, k.Sort, k.Refresh, k.Filter,
-		k.Containers, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks,
+		k.Containers, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks, k.Compose,
 		k.Inspect, k.RmDangling, k.Rm, k.ForceRm, k.RmUnused, k.History,
 	}
 }
@@ -207,10 +215,10 @@ func (k imagesKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{k.Shor
 // --- networks ---------------------------------------------------------
 
 type networksKeyMap struct {
-	Help, Quit                                    key.Binding
-	Sort, Refresh, Filter                         key.Binding
-	Containers, Images, Vols, Nodes, Svcs, Stacks key.Binding
-	Rm, Inspect                                   key.Binding
+	Help, Quit                                             key.Binding
+	Sort, Refresh, Filter                                  key.Binding
+	Containers, Images, Vols, Nodes, Svcs, Stacks, Compose key.Binding
+	Rm, Inspect                                            key.Binding
 }
 
 var networksKeys = networksKeyMap{
@@ -225,6 +233,7 @@ var networksKeys = networksKeyMap{
 	Nodes:      key.NewBinding(key.WithKeys("5"), key.WithHelp("5", "nodes")),
 	Svcs:       key.NewBinding(key.WithKeys("6"), key.WithHelp("6", "svcs")),
 	Stacks:     key.NewBinding(key.WithKeys("7"), key.WithHelp("7", "stacks")),
+	Compose:    key.NewBinding(key.WithKeys("8"), key.WithHelp("8", "compose")),
 	Rm:         key.NewBinding(key.WithKeys("ctrl+e"), key.WithHelp("^e", "rm")),
 	Inspect:    key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "inspect")),
 }
@@ -232,7 +241,7 @@ var networksKeys = networksKeyMap{
 func (k networksKeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.Help, k.Quit, k.Sort, k.Refresh, k.Filter,
-		k.Containers, k.Images, k.Vols, k.Nodes, k.Svcs, k.Stacks,
+		k.Containers, k.Images, k.Vols, k.Nodes, k.Svcs, k.Stacks, k.Compose,
 		k.Rm, k.Inspect,
 	}
 }
@@ -242,10 +251,10 @@ func (k networksKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{k.Sh
 // --- volumes ----------------------------------------------------------
 
 type volumesKeyMap struct {
-	Help, Quit                                    key.Binding
-	Sort, Refresh, Filter                         key.Binding
-	Containers, Images, Nets, Nodes, Svcs, Stacks key.Binding
-	RmAll, Rm, ForceRm, RmUnused, Inspect         key.Binding
+	Help, Quit                                             key.Binding
+	Sort, Refresh, Filter                                  key.Binding
+	Containers, Images, Nets, Nodes, Svcs, Stacks, Compose key.Binding
+	RmAll, Rm, ForceRm, RmUnused, Inspect                 key.Binding
 }
 
 var volumesKeys = volumesKeyMap{
@@ -260,6 +269,7 @@ var volumesKeys = volumesKeyMap{
 	Nodes:      key.NewBinding(key.WithKeys("5"), key.WithHelp("5", "nodes")),
 	Svcs:       key.NewBinding(key.WithKeys("6"), key.WithHelp("6", "svcs")),
 	Stacks:     key.NewBinding(key.WithKeys("7"), key.WithHelp("7", "stacks")),
+	Compose:    key.NewBinding(key.WithKeys("8"), key.WithHelp("8", "compose")),
 	RmAll:      key.NewBinding(key.WithKeys("ctrl+a"), key.WithHelp("^a", "rm all")),
 	Rm:         key.NewBinding(key.WithKeys("ctrl+e"), key.WithHelp("^e", "rm")),
 	ForceRm:    key.NewBinding(key.WithKeys("ctrl+f"), key.WithHelp("^f", "force rm")),
@@ -270,7 +280,7 @@ var volumesKeys = volumesKeyMap{
 func (k volumesKeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.Help, k.Quit, k.Sort, k.Refresh, k.Filter,
-		k.Containers, k.Images, k.Nets, k.Nodes, k.Svcs, k.Stacks,
+		k.Containers, k.Images, k.Nets, k.Nodes, k.Svcs, k.Stacks, k.Compose,
 		k.RmAll, k.Rm, k.ForceRm, k.RmUnused, k.Inspect,
 	}
 }
@@ -280,9 +290,9 @@ func (k volumesKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{k.Sho
 // --- disk usage -------------------------------------------------------
 
 type diskUsageKeyMap struct {
-	Help, Quit                                          key.Binding
-	Containers, Images, Nets, Vols, Nodes, Svcs, Stacks key.Binding
-	Prune                                               key.Binding
+	Help, Quit                                                   key.Binding
+	Containers, Images, Nets, Vols, Nodes, Svcs, Stacks, Compose key.Binding
+	Prune                                                        key.Binding
 }
 
 var diskUsageKeys = diskUsageKeyMap{
@@ -295,13 +305,14 @@ var diskUsageKeys = diskUsageKeyMap{
 	Nodes:      key.NewBinding(key.WithKeys("5"), key.WithHelp("5", "nodes")),
 	Svcs:       key.NewBinding(key.WithKeys("6"), key.WithHelp("6", "svcs")),
 	Stacks:     key.NewBinding(key.WithKeys("7"), key.WithHelp("7", "stacks")),
+	Compose:    key.NewBinding(key.WithKeys("8"), key.WithHelp("8", "compose")),
 	Prune:      key.NewBinding(key.WithKeys("p"), key.WithHelp("p", "prune")),
 }
 
 func (k diskUsageKeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.Help, k.Quit,
-		k.Containers, k.Images, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks,
+		k.Containers, k.Images, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks, k.Compose,
 		k.Prune,
 	}
 }
@@ -311,10 +322,10 @@ func (k diskUsageKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{k.S
 // --- services ---------------------------------------------------------
 
 type servicesKeyMap struct {
-	Help, Quit                                                   key.Binding
-	Sort, Refresh, Filter                                        key.Binding
-	Monitor, Containers, Images, Nets, Vols, Nodes, Svcs, Stacks key.Binding
-	Tasks, Inspect, Logs, Rm, Scale, Update                      key.Binding
+	Help, Quit                                                            key.Binding
+	Sort, Refresh, Filter                                                 key.Binding
+	Monitor, Containers, Images, Nets, Vols, Nodes, Svcs, Stacks, Compose key.Binding
+	Tasks, Inspect, Logs, Rm, Scale, Update                               key.Binding
 }
 
 var servicesKeys = servicesKeyMap{
@@ -328,6 +339,7 @@ var servicesKeys = servicesKeyMap{
 	Nodes:      key.NewBinding(key.WithKeys("5"), key.WithHelp("5", "nodes")),
 	Svcs:       key.NewBinding(key.WithKeys("6"), key.WithHelp("6", "svcs")),
 	Stacks:     key.NewBinding(key.WithKeys("7"), key.WithHelp("7", "stacks")),
+	Compose:    key.NewBinding(key.WithKeys("8"), key.WithHelp("8", "compose")),
 	Sort:       key.NewBinding(key.WithKeys("f1"), key.WithHelp("F1", "sort")),
 	Refresh:    key.NewBinding(key.WithKeys("f5"), key.WithHelp("F5", "refresh")),
 	Filter:     key.NewBinding(key.WithKeys("%"), key.WithHelp("%", "filter")),
@@ -342,7 +354,7 @@ var servicesKeys = servicesKeyMap{
 func (k servicesKeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.Help, k.Quit,
-		k.Monitor, k.Containers, k.Images, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks,
+		k.Monitor, k.Containers, k.Images, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks, k.Compose,
 		k.Sort, k.Refresh, k.Filter,
 		k.Tasks, k.Inspect, k.Logs, k.Rm, k.Scale, k.Update,
 	}
@@ -353,10 +365,10 @@ func (k servicesKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{k.Sh
 // --- stacks -----------------------------------------------------------
 
 type stacksKeyMap struct {
-	Help, Quit                                                   key.Binding
-	Sort, Refresh, Filter                                        key.Binding
-	Monitor, Containers, Images, Nets, Vols, Nodes, Svcs, Stacks key.Binding
-	Tasks, Rm                                                    key.Binding
+	Help, Quit                                                            key.Binding
+	Sort, Refresh, Filter                                                 key.Binding
+	Monitor, Containers, Images, Nets, Vols, Nodes, Svcs, Stacks, Compose key.Binding
+	Tasks, Rm                                                             key.Binding
 }
 
 var stacksKeys = stacksKeyMap{
@@ -370,6 +382,7 @@ var stacksKeys = stacksKeyMap{
 	Nodes:      key.NewBinding(key.WithKeys("5"), key.WithHelp("5", "nodes")),
 	Svcs:       key.NewBinding(key.WithKeys("6"), key.WithHelp("6", "svcs")),
 	Stacks:     key.NewBinding(key.WithKeys("7"), key.WithHelp("7", "stacks")),
+	Compose:    key.NewBinding(key.WithKeys("8"), key.WithHelp("8", "compose")),
 	Sort:       key.NewBinding(key.WithKeys("f1"), key.WithHelp("F1", "sort")),
 	Refresh:    key.NewBinding(key.WithKeys("f5"), key.WithHelp("F5", "refresh")),
 	Filter:     key.NewBinding(key.WithKeys("%"), key.WithHelp("%", "filter")),
@@ -380,7 +393,7 @@ var stacksKeys = stacksKeyMap{
 func (k stacksKeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.Help, k.Quit,
-		k.Monitor, k.Containers, k.Images, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks,
+		k.Monitor, k.Containers, k.Images, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks, k.Compose,
 		k.Sort, k.Refresh, k.Filter,
 		k.Tasks, k.Rm,
 	}
@@ -391,10 +404,10 @@ func (k stacksKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{k.Shor
 // --- nodes ------------------------------------------------------------
 
 type nodesKeyMap struct {
-	Help, Quit                                                   key.Binding
-	Sort, Refresh, Filter                                        key.Binding
-	Monitor, Containers, Images, Nets, Vols, Nodes, Svcs, Stacks key.Binding
-	Tasks, Inspect, Availability                                 key.Binding
+	Help, Quit                                                            key.Binding
+	Sort, Refresh, Filter                                                 key.Binding
+	Monitor, Containers, Images, Nets, Vols, Nodes, Svcs, Stacks, Compose key.Binding
+	Tasks, Inspect, Availability                                          key.Binding
 }
 
 var nodesKeys = nodesKeyMap{
@@ -408,6 +421,7 @@ var nodesKeys = nodesKeyMap{
 	Nodes:        key.NewBinding(key.WithKeys("5"), key.WithHelp("5", "nodes")),
 	Svcs:         key.NewBinding(key.WithKeys("6"), key.WithHelp("6", "svcs")),
 	Stacks:       key.NewBinding(key.WithKeys("7"), key.WithHelp("7", "stacks")),
+	Compose:      key.NewBinding(key.WithKeys("8"), key.WithHelp("8", "compose")),
 	Sort:         key.NewBinding(key.WithKeys("f1"), key.WithHelp("F1", "sort")),
 	Refresh:      key.NewBinding(key.WithKeys("f5"), key.WithHelp("F5", "refresh")),
 	Filter:       key.NewBinding(key.WithKeys("%"), key.WithHelp("%", "filter")),
@@ -419,7 +433,7 @@ var nodesKeys = nodesKeyMap{
 func (k nodesKeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.Help, k.Quit,
-		k.Monitor, k.Containers, k.Images, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks,
+		k.Monitor, k.Containers, k.Images, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks, k.Compose,
 		k.Sort, k.Refresh, k.Filter,
 		k.Tasks, k.Inspect, k.Availability,
 	}
@@ -447,3 +461,62 @@ func (k tasksKeyMap) ShortHelp() []key.Binding {
 }
 
 func (k tasksKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{k.ShortHelp()} }
+
+// --- compose projects -----------------------------------------------------
+
+type composeProjectsKeyMap struct {
+	Help, Quit                                                            key.Binding
+	Sort, Refresh, Filter                                                 key.Binding
+	Monitor, Containers, Images, Nets, Vols, Nodes, Svcs, Stacks, Compose key.Binding
+	Enter                                                                 key.Binding
+}
+
+var composeProjectsKeys = composeProjectsKeyMap{
+	Help:       key.NewBinding(key.WithKeys("h"), key.WithHelp("h", "help")),
+	Quit:       key.NewBinding(key.WithKeys("Q"), key.WithHelp("q", "quit")),
+	Sort:       key.NewBinding(key.WithKeys("f1"), key.WithHelp("F1", "sort")),
+	Refresh:    key.NewBinding(key.WithKeys("f5"), key.WithHelp("F5", "refresh")),
+	Filter:     key.NewBinding(key.WithKeys("%"), key.WithHelp("%", "filter")),
+	Monitor:    key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "monitor")),
+	Containers: key.NewBinding(key.WithKeys("1"), key.WithHelp("1", "containers")),
+	Images:     key.NewBinding(key.WithKeys("2"), key.WithHelp("2", "images")),
+	Nets:       key.NewBinding(key.WithKeys("3"), key.WithHelp("3", "nets")),
+	Vols:       key.NewBinding(key.WithKeys("4"), key.WithHelp("4", "vols")),
+	Nodes:      key.NewBinding(key.WithKeys("5"), key.WithHelp("5", "nodes")),
+	Svcs:       key.NewBinding(key.WithKeys("6"), key.WithHelp("6", "svcs")),
+	Stacks:     key.NewBinding(key.WithKeys("7"), key.WithHelp("7", "stacks")),
+	Compose:    key.NewBinding(key.WithKeys("8"), key.WithHelp("8", "compose")),
+	Enter:      key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "services")),
+}
+
+func (k composeProjectsKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{
+		k.Help, k.Quit, k.Sort, k.Refresh, k.Filter,
+		k.Monitor, k.Containers, k.Images, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks, k.Compose,
+		k.Enter,
+	}
+}
+
+func (k composeProjectsKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{k.ShortHelp()} }
+
+// --- compose services -----------------------------------------------------
+
+type composeServicesKeyMap struct {
+	Help, Quit    key.Binding
+	Sort, Filter  key.Binding
+	Back          key.Binding
+}
+
+var composeServicesKeys = composeServicesKeyMap{
+	Help:   key.NewBinding(key.WithKeys("h"), key.WithHelp("h", "help")),
+	Quit:   key.NewBinding(key.WithKeys("Q"), key.WithHelp("q", "quit")),
+	Sort:   key.NewBinding(key.WithKeys("f1"), key.WithHelp("F1", "sort")),
+	Filter: key.NewBinding(key.WithKeys("%"), key.WithHelp("%", "filter")),
+	Back:   key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+}
+
+func (k composeServicesKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Help, k.Quit, k.Sort, k.Filter, k.Back}
+}
+
+func (k composeServicesKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{k.ShortHelp()} }

--- a/app/view.go
+++ b/app/view.go
@@ -28,4 +28,8 @@ const (
 	Tasks
 	// Volumes is the volume list view
 	Volumes
+	// ComposeProjects is the compose project list view
+	ComposeProjects
+	// ComposeServices shows services for a compose project
+	ComposeServices
 )

--- a/appui/compose/projects_model.go
+++ b/appui/compose/projects_model.go
@@ -1,0 +1,222 @@
+package compose
+
+import (
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/moncho/dry/appui"
+	"github.com/moncho/dry/docker"
+)
+
+// projectHeaderRow is a group header for a compose project.
+type projectHeaderRow struct {
+	project docker.ComposeProject
+	columns []string
+}
+
+func newProjectHeaderRow(p docker.ComposeProject) projectHeaderRow {
+	name := appui.ColorFg(p.Name, appui.DryTheme.Info)
+	return projectHeaderRow{
+		project: p,
+		columns: []string{
+			name,
+			fmt.Sprintf("%d", p.Containers),
+			fmt.Sprintf("%d", p.Running),
+			fmt.Sprintf("%d", p.Exited),
+			"",
+			"",
+			"",
+		},
+	}
+}
+
+func (r projectHeaderRow) Columns() []string { return r.columns }
+func (r projectHeaderRow) ID() string        { return r.project.Name }
+
+// serviceDetailRow is an indented row for a service within a project.
+type serviceDetailRow struct {
+	service     docker.ComposeService
+	projectName string
+	columns     []string
+}
+
+func newServiceDetailRow(s docker.ComposeService) serviceDetailRow {
+	return serviceDetailRow{
+		service:     s,
+		projectName: s.Project,
+		columns: []string{
+			"  " + s.Name,
+			fmt.Sprintf("%d", s.Containers),
+			fmt.Sprintf("%d", s.Running),
+			fmt.Sprintf("%d", s.Exited),
+			s.Image,
+			colorHealth(s.Health),
+			s.Ports,
+		},
+	}
+}
+
+// colorHealth applies theme colors to health status text.
+func colorHealth(h string) string {
+	switch h {
+	case "unhealthy":
+		return appui.ColorFg(h, appui.DryTheme.Error)
+	case "healthy":
+		return appui.ColorFg(h, appui.DryTheme.Success)
+	case "starting":
+		return appui.ColorFg(h, appui.DryTheme.Warning)
+	default:
+		return h
+	}
+}
+
+func (r serviceDetailRow) Columns() []string { return r.columns }
+func (r serviceDetailRow) ID() string        { return r.projectName + "/" + r.service.Name }
+
+// ProjectsLoadedMsg carries the loaded compose projects with services.
+type ProjectsLoadedMsg struct {
+	Projects []docker.ProjectWithServices
+}
+
+// ProjectsModel is the Compose projects list view.
+type ProjectsModel struct {
+	table    appui.TableModel
+	filter   appui.FilterInputModel
+	daemon   docker.ContainerDaemon
+	projects []docker.ProjectWithServices
+}
+
+// NewProjectsModel creates a compose projects list model.
+func NewProjectsModel() ProjectsModel {
+	columns := []appui.Column{
+		{Title: "NAME"},
+		{Title: "CONTAINERS", Width: 12, Fixed: true},
+		{Title: "RUNNING", Width: 10, Fixed: true},
+		{Title: "EXITED", Width: 10, Fixed: true},
+		{Title: "IMAGE"},
+		{Title: "HEALTH", Width: 12, Fixed: true},
+		{Title: "PORTS"},
+	}
+	return ProjectsModel{
+		table:  appui.NewTableModel(columns),
+		filter: appui.NewFilterInputModel(),
+	}
+}
+
+// SetDaemon sets the Docker daemon reference.
+func (m *ProjectsModel) SetDaemon(d docker.ContainerDaemon) {
+	m.daemon = d
+}
+
+// FilterActive returns true when the filter input is active.
+func (m ProjectsModel) FilterActive() bool { return m.filter.Active() }
+
+// SetSize updates the table dimensions.
+func (m *ProjectsModel) SetSize(w, h int) {
+	filterH := 0
+	if m.filter.Active() {
+		filterH = 1
+	}
+	m.table.SetSize(w, h-2-filterH)
+	m.filter.SetWidth(w)
+}
+
+// SetProjects replaces the project list with interleaved project+service rows.
+func (m *ProjectsModel) SetProjects(projects []docker.ProjectWithServices) {
+	m.projects = projects
+	var rows []appui.TableRow
+	for _, pws := range projects {
+		rows = append(rows, newProjectHeaderRow(pws.Project))
+		for _, svc := range pws.Services {
+			rows = append(rows, newServiceDetailRow(svc))
+		}
+	}
+	m.table.SetRows(rows)
+}
+
+// SelectedService returns the service under the cursor, or nil if on a project row.
+func (m ProjectsModel) SelectedService() *docker.ComposeService {
+	row := m.table.SelectedRow()
+	if row == nil {
+		return nil
+	}
+	if r, ok := row.(serviceDetailRow); ok {
+		return &r.service
+	}
+	return nil
+}
+
+// SelectedProject returns the project under the cursor, or nil.
+// If the cursor is on a service row, returns the parent project.
+func (m ProjectsModel) SelectedProject() *docker.ComposeProject {
+	row := m.table.SelectedRow()
+	if row == nil {
+		return nil
+	}
+	switch r := row.(type) {
+	case projectHeaderRow:
+		return &r.project
+	case serviceDetailRow:
+		for i := range m.projects {
+			if m.projects[i].Project.Name == r.projectName {
+				return &m.projects[i].Project
+			}
+		}
+	}
+	return nil
+}
+
+// Update handles key events.
+func (m ProjectsModel) Update(msg tea.Msg) (ProjectsModel, tea.Cmd) {
+	if m.filter.Active() {
+		var cmd tea.Cmd
+		m.filter, cmd = m.filter.Update(msg)
+		m.table.SetFilter(m.filter.Value())
+		return m, cmd
+	}
+
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "f1":
+			m.table.NextSort()
+			return m, nil
+		case "f5":
+			return m, nil
+		case "%":
+			cmd := m.filter.Activate()
+			return m, cmd
+		}
+	}
+	var cmd tea.Cmd
+	m.table, cmd = m.table.Update(msg)
+	return m, cmd
+}
+
+// View renders the projects list.
+func (m ProjectsModel) View() string {
+	header := m.widgetHeader()
+	tableView := m.table.View()
+	result := header + "\n" + tableView
+	if filterView := m.filter.View(); filterView != "" {
+		result += "\n" + filterView
+	}
+	return result
+}
+
+// RefreshTableStyles re-applies theme styles to the inner table.
+func (m *ProjectsModel) RefreshTableStyles() {
+	m.table.RefreshStyles()
+}
+
+func (m ProjectsModel) widgetHeader() string {
+	return appui.RenderWidgetHeader(appui.WidgetHeaderOpts{
+		Icon:     "\U0001f433",
+		Title:    "Compose Projects",
+		Total:    m.table.TotalRowCount(),
+		Filtered: m.table.RowCount(),
+		Filter:   m.table.FilterText(),
+		Width:    m.table.Width(),
+		Accent:   appui.DryTheme.Info,
+	})
+}

--- a/appui/compose/services_model.go
+++ b/appui/compose/services_model.go
@@ -1,0 +1,242 @@
+package compose
+
+import (
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/moncho/dry/appui"
+	"github.com/moncho/dry/docker"
+)
+
+// serviceRow wraps a ComposeService as a TableRow.
+type serviceRow struct {
+	service docker.ComposeService
+	columns []string
+}
+
+func newServiceRow(s docker.ComposeService) serviceRow {
+	return serviceRow{
+		service: s,
+		columns: []string{
+			"  " + s.Name,
+			fmt.Sprintf("%d", s.Containers),
+			fmt.Sprintf("%d", s.Running),
+			fmt.Sprintf("%d", s.Exited),
+			s.Image,
+			colorHealth(s.Health),
+			s.Ports,
+		},
+	}
+}
+
+func (r serviceRow) Columns() []string { return r.columns }
+func (r serviceRow) ID() string        { return r.service.Name }
+
+// sectionRow is a visual group header separating resource types.
+type sectionRow struct {
+	label   string
+	columns []string
+}
+
+func newSectionRow(label string, count int) sectionRow {
+	title := appui.ColorFg(fmt.Sprintf("%s (%d)", label, count), appui.DryTheme.Info)
+	return sectionRow{
+		label:   label,
+		columns: []string{title, "", "", "", "", "", ""},
+	}
+}
+
+func (r sectionRow) Columns() []string { return r.columns }
+func (r sectionRow) ID() string        { return "section:" + r.label }
+
+// networkRow wraps a ComposeNetwork as a TableRow.
+type networkRow struct {
+	network docker.ComposeNetwork
+	columns []string
+}
+
+func newNetworkRow(n docker.ComposeNetwork) networkRow {
+	return networkRow{
+		network: n,
+		columns: []string{"  " + n.Name, "", "", "", n.Driver, n.Scope, ""},
+	}
+}
+
+func (r networkRow) Columns() []string { return r.columns }
+func (r networkRow) ID() string        { return "net:" + r.network.Name }
+
+// volumeRow wraps a ComposeVolume as a TableRow.
+type volumeRow struct {
+	volume  docker.ComposeVolume
+	columns []string
+}
+
+func newVolumeRow(v docker.ComposeVolume) volumeRow {
+	return volumeRow{
+		volume: v,
+		columns: []string{"  " + v.Name, "", "", "", v.Driver, "", ""},
+	}
+}
+
+func (r volumeRow) Columns() []string { return r.columns }
+func (r volumeRow) ID() string        { return "vol:" + r.volume.Name }
+
+// ServicesLoadedMsg carries loaded compose resources for a project.
+type ServicesLoadedMsg struct {
+	Services []docker.ComposeService
+	Networks []docker.ComposeNetwork
+	Volumes  []docker.ComposeVolume
+	Project  string
+}
+
+// ServicesModel is the Compose project resources view.
+type ServicesModel struct {
+	table   appui.TableModel
+	filter  appui.FilterInputModel
+	project string
+}
+
+// NewServicesModel creates a compose services list model.
+func NewServicesModel() ServicesModel {
+	columns := []appui.Column{
+		{Title: "NAME"},
+		{Title: "CONTAINERS", Width: 12, Fixed: true},
+		{Title: "RUNNING", Width: 10, Fixed: true},
+		{Title: "EXITED", Width: 10, Fixed: true},
+		{Title: "IMAGE/DRIVER"},
+		{Title: "HEALTH/SCOPE", Width: 14, Fixed: true},
+		{Title: "PORTS"},
+	}
+	return ServicesModel{
+		table:  appui.NewTableModel(columns),
+		filter: appui.NewFilterInputModel(),
+	}
+}
+
+// FilterActive returns true when the filter input is active.
+func (m ServicesModel) FilterActive() bool { return m.filter.Active() }
+
+// SetSize updates the table dimensions.
+func (m *ServicesModel) SetSize(w, h int) {
+	filterH := 0
+	if m.filter.Active() {
+		filterH = 1
+	}
+	m.table.SetSize(w, h-2-filterH)
+	m.filter.SetWidth(w)
+}
+
+// SetServices replaces the resource list with services, networks, and volumes.
+func (m *ServicesModel) SetServices(services []docker.ComposeService, networks []docker.ComposeNetwork, volumes []docker.ComposeVolume, project string) {
+	m.project = project
+	var rows []appui.TableRow
+
+	if len(services) > 0 {
+		rows = append(rows, newSectionRow("Services", len(services)))
+		for _, s := range services {
+			rows = append(rows, newServiceRow(s))
+		}
+	}
+	if len(networks) > 0 {
+		rows = append(rows, newSectionRow("Networks", len(networks)))
+		for _, n := range networks {
+			rows = append(rows, newNetworkRow(n))
+		}
+	}
+	if len(volumes) > 0 {
+		rows = append(rows, newSectionRow("Volumes", len(volumes)))
+		for _, v := range volumes {
+			rows = append(rows, newVolumeRow(v))
+		}
+	}
+
+	m.table.SetRows(rows)
+}
+
+// SelectedService returns the service under the cursor, or nil.
+func (m ServicesModel) SelectedService() *docker.ComposeService {
+	row := m.table.SelectedRow()
+	if row == nil {
+		return nil
+	}
+	if r, ok := row.(serviceRow); ok {
+		return &r.service
+	}
+	return nil
+}
+
+// SelectedNetwork returns the network under the cursor, or nil.
+func (m ServicesModel) SelectedNetwork() *docker.ComposeNetwork {
+	row := m.table.SelectedRow()
+	if row == nil {
+		return nil
+	}
+	if r, ok := row.(networkRow); ok {
+		return &r.network
+	}
+	return nil
+}
+
+// SelectedVolume returns the volume under the cursor, or nil.
+func (m ServicesModel) SelectedVolume() *docker.ComposeVolume {
+	row := m.table.SelectedRow()
+	if row == nil {
+		return nil
+	}
+	if r, ok := row.(volumeRow); ok {
+		return &r.volume
+	}
+	return nil
+}
+
+// Update handles key events.
+func (m ServicesModel) Update(msg tea.Msg) (ServicesModel, tea.Cmd) {
+	if m.filter.Active() {
+		var cmd tea.Cmd
+		m.filter, cmd = m.filter.Update(msg)
+		m.table.SetFilter(m.filter.Value())
+		return m, cmd
+	}
+
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "f1":
+			m.table.NextSort()
+			return m, nil
+		case "%":
+			cmd := m.filter.Activate()
+			return m, cmd
+		}
+	}
+	var cmd tea.Cmd
+	m.table, cmd = m.table.Update(msg)
+	return m, cmd
+}
+
+// View renders the services list.
+func (m ServicesModel) View() string {
+	title := "Compose Resources"
+	if m.project != "" {
+		title = fmt.Sprintf("Compose: %s", m.project)
+	}
+	header := appui.RenderWidgetHeader(appui.WidgetHeaderOpts{
+		Icon:     "\U0001f433",
+		Title:    title,
+		Total:    m.table.TotalRowCount(),
+		Filtered: m.table.RowCount(),
+		Filter:   m.table.FilterText(),
+		Width:    m.table.Width(),
+		Accent:   appui.DryTheme.Info,
+	})
+	result := header + "\n" + m.table.View()
+	if filterView := m.filter.View(); filterView != "" {
+		result += "\n" + filterView
+	}
+	return result
+}
+
+// RefreshTableStyles re-applies theme styles to the inner table.
+func (m *ServicesModel) RefreshTableStyles() {
+	m.table.RefreshStyles()
+}

--- a/docker/api.go
+++ b/docker/api.go
@@ -21,6 +21,14 @@ type Container struct {
 	Detail container.InspectResponse
 }
 
+// ComposeAPI defines methods to query Docker Compose project/service information
+// derived from container labels.
+type ComposeAPI interface {
+	ComposeProjects() []ComposeProject
+	ComposeProjectsWithServices() []ProjectWithServices
+	ComposeServices(project string) []ComposeService
+}
+
 // ContainerDaemon describes what is expected from the container daemon
 type ContainerDaemon interface {
 	ContainerAPI
@@ -28,6 +36,7 @@ type ContainerDaemon interface {
 	NetworkAPI
 	VolumesAPI
 	SwarmAPI
+	ComposeAPI
 	ContainerRuntime
 	DiskUsage() (types.DiskUsage, error)
 	DockerEnv() Env

--- a/docker/compose.go
+++ b/docker/compose.go
@@ -1,0 +1,234 @@
+package docker
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/docker/docker/api/types/container"
+)
+
+// ComposeProject represents a Docker Compose project aggregated from container labels.
+type ComposeProject struct {
+	Name       string
+	Services   int
+	Containers int
+	Running    int
+	Exited     int
+}
+
+// ComposeNetwork represents a network created by Docker Compose.
+type ComposeNetwork struct {
+	Name   string
+	Driver string
+	Scope  string
+}
+
+// ComposeVolume represents a volume created by Docker Compose.
+type ComposeVolume struct {
+	Name   string
+	Driver string
+}
+
+// ComposeService represents a service within a Docker Compose project.
+type ComposeService struct {
+	Project    string
+	Name       string
+	Containers int
+	Running    int
+	Exited     int
+	Image      string
+	Health     string // "healthy", "unhealthy", "starting", "none", or ""
+	Ports      string // formatted listening ports
+}
+
+// ProjectWithServices pairs a project with its services.
+type ProjectWithServices struct {
+	Project  ComposeProject
+	Services []ComposeService
+}
+
+// AggregateComposeAll produces projects with their services embedded in a single pass.
+func AggregateComposeAll(containers []*Container) []ProjectWithServices {
+	projects := AggregateComposeProjects(containers)
+	result := make([]ProjectWithServices, len(projects))
+	for i, p := range projects {
+		result[i] = ProjectWithServices{
+			Project:  p,
+			Services: AggregateComposeServices(containers, p.Name),
+		}
+	}
+	return result
+}
+
+// AggregateComposeProjects groups containers by their com.docker.compose.project label.
+func AggregateComposeProjects(containers []*Container) []ComposeProject {
+	type projectAcc struct {
+		services   map[string]bool
+		containers int
+		running    int
+		exited     int
+	}
+	projects := make(map[string]*projectAcc)
+	for _, c := range containers {
+		project := c.Labels["com.docker.compose.project"]
+		service := c.Labels["com.docker.compose.service"]
+		if project == "" || service == "" {
+			continue
+		}
+		if c.Labels["com.docker.compose.oneoff"] == "True" {
+			continue
+		}
+		acc, ok := projects[project]
+		if !ok {
+			acc = &projectAcc{services: make(map[string]bool)}
+			projects[project] = acc
+		}
+		acc.services[service] = true
+		acc.containers++
+		if IsContainerRunning(c) {
+			acc.running++
+		} else {
+			acc.exited++
+		}
+	}
+
+	result := make([]ComposeProject, 0, len(projects))
+	for name, acc := range projects {
+		result = append(result, ComposeProject{
+			Name:       name,
+			Services:   len(acc.services),
+			Containers: acc.containers,
+			Running:    acc.running,
+			Exited:     acc.exited,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+// AggregateComposeServices groups containers for a specific project by their
+// com.docker.compose.service label.
+func AggregateComposeServices(containers []*Container, project string) []ComposeService {
+	type serviceAcc struct {
+		containers int
+		running    int
+		exited     int
+		image      string
+		healths    []string
+		ports      []container.Port
+	}
+	services := make(map[string]*serviceAcc)
+	for _, c := range containers {
+		if c.Labels["com.docker.compose.project"] != project {
+			continue
+		}
+		svc := c.Labels["com.docker.compose.service"]
+		if svc == "" {
+			continue
+		}
+		if c.Labels["com.docker.compose.oneoff"] == "True" {
+			continue
+		}
+		acc, ok := services[svc]
+		if !ok {
+			acc = &serviceAcc{}
+			services[svc] = acc
+		}
+		acc.containers++
+		if IsContainerRunning(c) {
+			acc.running++
+		} else {
+			acc.exited++
+		}
+		if acc.image == "" && c.Image != "" {
+			acc.image = c.Image
+		}
+		health := ""
+		if c.Detail.ContainerJSONBase != nil && c.Detail.State != nil && c.Detail.State.Health != nil {
+			health = c.Detail.State.Health.Status
+		}
+		acc.healths = append(acc.healths, health)
+		acc.ports = append(acc.ports, c.Ports...)
+	}
+
+	result := make([]ComposeService, 0, len(services))
+	for name, acc := range services {
+		result = append(result, ComposeService{
+			Project:    project,
+			Name:       name,
+			Containers: acc.containers,
+			Running:    acc.running,
+			Exited:     acc.exited,
+			Image:      acc.image,
+			Health:     aggregateHealth(acc.healths),
+			Ports:      aggregatePorts(acc.ports),
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+// aggregateHealth derives a single health status from individual container health statuses.
+// If any unhealthy -> "unhealthy", else if any starting -> "starting",
+// else if all healthy -> "healthy", else "none".
+func aggregateHealth(healths []string) string {
+	hasHealthy := false
+	for _, h := range healths {
+		switch h {
+		case "unhealthy":
+			return "unhealthy"
+		case "healthy":
+			hasHealthy = true
+		}
+	}
+	for _, h := range healths {
+		if h == "starting" {
+			return "starting"
+		}
+	}
+	if hasHealthy {
+		return "healthy"
+	}
+	return "none"
+}
+
+// aggregatePorts deduplicates and formats ports from all containers in a service.
+func aggregatePorts(ports []container.Port) string {
+	if len(ports) == 0 {
+		return ""
+	}
+	// Deduplicate by (IP, PublicPort, PrivatePort, Type) tuple.
+	type portKey struct {
+		IP          string
+		PublicPort  uint16
+		PrivatePort uint16
+		Type        string
+	}
+	seen := make(map[portKey]bool)
+	var unique []container.Port
+	for _, p := range ports {
+		k := portKey{p.IP, p.PublicPort, p.PrivatePort, p.Type}
+		if !seen[k] {
+			seen[k] = true
+			unique = append(unique, p)
+		}
+	}
+	// Sort by private port for consistent display.
+	sort.Slice(unique, func(i, j int) bool {
+		return unique[i].PrivatePort < unique[j].PrivatePort
+	})
+	var parts []string
+	for _, p := range unique {
+		if p.PublicPort != 0 {
+			parts = append(parts, fmt.Sprintf("%s:%d->%d/%s", p.IP, p.PublicPort, p.PrivatePort, p.Type))
+		} else {
+			parts = append(parts, fmt.Sprintf("%d/%s", p.PrivatePort, p.Type))
+		}
+	}
+	return strings.Join(parts, ", ")
+}

--- a/docker/compose_test.go
+++ b/docker/compose_test.go
@@ -1,0 +1,204 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+)
+
+func TestAggregateComposeProjects(t *testing.T) {
+	tests := []struct {
+		name       string
+		containers []*Container
+		wantCount  int
+		check      func(t *testing.T, projects []ComposeProject)
+	}{
+		{
+			name:       "empty input",
+			containers: nil,
+			wantCount:  0,
+		},
+		{
+			name: "missing labels skipped",
+			containers: []*Container{
+				makeContainer("c1", "Up 1h", map[string]string{}, "img:latest"),
+			},
+			wantCount: 0,
+		},
+		{
+			name: "one-off containers excluded",
+			containers: []*Container{
+				makeContainer("c1", "Up 1h", map[string]string{
+					"com.docker.compose.project": "web",
+					"com.docker.compose.service": "api",
+					"com.docker.compose.oneoff":  "True",
+				}, "img:latest"),
+			},
+			wantCount: 0,
+		},
+		{
+			name: "mixed running and exited",
+			containers: []*Container{
+				makeContainer("c1", "Up 1h", map[string]string{
+					"com.docker.compose.project": "web",
+					"com.docker.compose.service": "api",
+				}, "api:latest"),
+				makeContainer("c2", "Exited (0) 5m", map[string]string{
+					"com.docker.compose.project": "web",
+					"com.docker.compose.service": "worker",
+				}, "worker:latest"),
+				makeContainer("c3", "Up 2h", map[string]string{
+					"com.docker.compose.project": "web",
+					"com.docker.compose.service": "api",
+				}, "api:latest"),
+			},
+			wantCount: 1,
+			check: func(t *testing.T, projects []ComposeProject) {
+				p := projects[0]
+				if p.Name != "web" {
+					t.Errorf("expected project name 'web', got %q", p.Name)
+				}
+				if p.Services != 2 {
+					t.Errorf("expected 2 services, got %d", p.Services)
+				}
+				if p.Containers != 3 {
+					t.Errorf("expected 3 containers, got %d", p.Containers)
+				}
+				if p.Running != 2 {
+					t.Errorf("expected 2 running, got %d", p.Running)
+				}
+				if p.Exited != 1 {
+					t.Errorf("expected 1 exited, got %d", p.Exited)
+				}
+			},
+		},
+		{
+			name: "multiple projects sorted by name",
+			containers: []*Container{
+				makeContainer("c1", "Up 1h", map[string]string{
+					"com.docker.compose.project": "zoo",
+					"com.docker.compose.service": "app",
+				}, "zoo:latest"),
+				makeContainer("c2", "Up 1h", map[string]string{
+					"com.docker.compose.project": "alpha",
+					"com.docker.compose.service": "web",
+				}, "alpha:latest"),
+			},
+			wantCount: 2,
+			check: func(t *testing.T, projects []ComposeProject) {
+				if projects[0].Name != "alpha" {
+					t.Errorf("expected first project 'alpha', got %q", projects[0].Name)
+				}
+				if projects[1].Name != "zoo" {
+					t.Errorf("expected second project 'zoo', got %q", projects[1].Name)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projects := AggregateComposeProjects(tt.containers)
+			if len(projects) != tt.wantCount {
+				t.Fatalf("expected %d projects, got %d", tt.wantCount, len(projects))
+			}
+			if tt.check != nil {
+				tt.check(t, projects)
+			}
+		})
+	}
+}
+
+func TestAggregateComposeServices(t *testing.T) {
+	containers := []*Container{
+		makeContainer("c1", "Up 1h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+		makeContainer("c2", "Exited (0) 5m", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+		makeContainer("c3", "Up 2h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "db",
+		}, "postgres:15"),
+		// Different project — should be excluded
+		makeContainer("c4", "Up 1h", map[string]string{
+			"com.docker.compose.project": "other",
+			"com.docker.compose.service": "svc",
+		}, "other:latest"),
+		// One-off — should be excluded
+		makeContainer("c5", "Up 1h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+			"com.docker.compose.oneoff":  "True",
+		}, "api:latest"),
+	}
+
+	services := AggregateComposeServices(containers, "web")
+	if len(services) != 2 {
+		t.Fatalf("expected 2 services, got %d", len(services))
+	}
+
+	// Sorted by name: api, db
+	api := services[0]
+	if api.Name != "api" {
+		t.Errorf("expected service 'api', got %q", api.Name)
+	}
+	if api.Containers != 2 {
+		t.Errorf("expected 2 containers for api, got %d", api.Containers)
+	}
+	if api.Running != 1 {
+		t.Errorf("expected 1 running for api, got %d", api.Running)
+	}
+	if api.Exited != 1 {
+		t.Errorf("expected 1 exited for api, got %d", api.Exited)
+	}
+	if api.Image != "api:latest" {
+		t.Errorf("expected image 'api:latest', got %q", api.Image)
+	}
+
+	db := services[1]
+	if db.Name != "db" {
+		t.Errorf("expected service 'db', got %q", db.Name)
+	}
+	if db.Image != "postgres:15" {
+		t.Errorf("expected image 'postgres:15', got %q", db.Image)
+	}
+}
+
+func TestAggregateHealth(t *testing.T) {
+	tests := []struct {
+		name    string
+		healths []string
+		want    string
+	}{
+		{"empty", nil, "none"},
+		{"all healthy", []string{"healthy", "healthy"}, "healthy"},
+		{"any unhealthy", []string{"healthy", "unhealthy"}, "unhealthy"},
+		{"any starting", []string{"healthy", "starting"}, "starting"},
+		{"unhealthy takes priority over starting", []string{"unhealthy", "starting"}, "unhealthy"},
+		{"no health info", []string{"", ""}, "none"},
+		{"mixed healthy and none", []string{"healthy", ""}, "healthy"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := aggregateHealth(tt.healths)
+			if got != tt.want {
+				t.Errorf("aggregateHealth(%v) = %q, want %q", tt.healths, got, tt.want)
+			}
+		})
+	}
+}
+
+func makeContainer(id, status string, labels map[string]string, image string) *Container {
+	return &Container{
+		Summary: container.Summary{
+			ID:     id,
+			Status: status,
+			Labels: labels,
+			Image:  image,
+		},
+	}
+}

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -595,6 +595,21 @@ func networks(client dockerAPI.NetworkAPIClient) ([]network.Inspect, error) {
 	return detailedNetworks, nil
 }
 
+// ComposeProjects returns Docker Compose projects derived from container labels.
+func (daemon *DockerDaemon) ComposeProjects() []ComposeProject {
+	return AggregateComposeProjects(daemon.Containers(nil, SortByContainerID))
+}
+
+// ComposeProjectsWithServices returns Docker Compose projects with their services.
+func (daemon *DockerDaemon) ComposeProjectsWithServices() []ProjectWithServices {
+	return AggregateComposeAll(daemon.Containers(nil, SortByContainerID))
+}
+
+// ComposeServices returns Docker Compose services for a given project.
+func (daemon *DockerDaemon) ComposeServices(project string) []ComposeService {
+	return AggregateComposeServices(daemon.Containers(nil, SortByContainerID), project)
+}
+
 // IsContainerRunning returns true if the given container is running
 func IsContainerRunning(container *Container) bool {
 	if container != nil {

--- a/mocks/docker_daemon.go
+++ b/mocks/docker_daemon.go
@@ -21,6 +21,44 @@ import (
 type DockerDaemonMock struct {
 }
 
+// ComposeProjects mock
+func (_m *DockerDaemonMock) ComposeProjects() []drydocker.ComposeProject {
+	return []drydocker.ComposeProject{
+		{Name: "webapp", Services: 3, Containers: 4, Running: 3, Exited: 1},
+		{Name: "monitoring", Services: 2, Containers: 2, Running: 2, Exited: 0},
+	}
+}
+
+// ComposeProjectsWithServices mock
+func (_m *DockerDaemonMock) ComposeProjectsWithServices() []drydocker.ProjectWithServices {
+	return []drydocker.ProjectWithServices{
+		{
+			Project: drydocker.ComposeProject{Name: "webapp", Services: 3, Containers: 4, Running: 3, Exited: 1},
+			Services: []drydocker.ComposeService{
+				{Project: "webapp", Name: "api", Containers: 2, Running: 2, Exited: 0, Image: "api:latest", Health: "healthy", Ports: "0.0.0.0:8080->8080/tcp"},
+				{Project: "webapp", Name: "db", Containers: 1, Running: 1, Exited: 0, Image: "postgres:15", Health: "none", Ports: "0.0.0.0:5432->5432/tcp"},
+				{Project: "webapp", Name: "worker", Containers: 1, Running: 0, Exited: 1, Image: "worker:latest", Health: "none"},
+			},
+		},
+		{
+			Project: drydocker.ComposeProject{Name: "monitoring", Services: 2, Containers: 2, Running: 2, Exited: 0},
+			Services: []drydocker.ComposeService{
+				{Project: "monitoring", Name: "grafana", Containers: 1, Running: 1, Exited: 0, Image: "grafana/grafana:latest", Health: "healthy", Ports: "0.0.0.0:3000->3000/tcp"},
+				{Project: "monitoring", Name: "prometheus", Containers: 1, Running: 1, Exited: 0, Image: "prom/prometheus:latest", Health: "healthy", Ports: "0.0.0.0:9090->9090/tcp"},
+			},
+		},
+	}
+}
+
+// ComposeServices mock
+func (_m *DockerDaemonMock) ComposeServices(project string) []drydocker.ComposeService {
+	return []drydocker.ComposeService{
+		{Project: project, Name: "api", Containers: 2, Running: 2, Exited: 0, Image: "api:latest", Health: "healthy", Ports: "0.0.0.0:8080->8080/tcp"},
+		{Project: project, Name: "db", Containers: 1, Running: 1, Exited: 0, Image: "postgres:15", Health: "none", Ports: "0.0.0.0:5432->5432/tcp"},
+		{Project: project, Name: "worker", Containers: 1, Running: 0, Exited: 1, Image: "worker:latest", Health: "none"},
+	}
+}
+
 // ContainerByID mock
 func (_m *DockerDaemonMock) ContainerByID(id string) *drydocker.Container {
 	return nil


### PR DESCRIPTION

Add the Compose Projects view (key 8) showing projects with their services listed inline as a grouped tree-style display. Drilling into a project shows all its resources: services, networks, and volumes.

- Add ProjectWithServices type and aggregation in docker/compose.go
- Add ComposeProjectsWithServices to ComposeAPI interface and daemon
- Rework projects_model.go with mixed projectHeaderRow/serviceDetailRow
- Color health column: red=unhealthy, green=healthy, yellow=starting
- Collect and display per-service listening ports from container data
- Bind l/L in both Compose views for merged multi-container log streaming
- Show networks and volumes in ComposeServices drill-down view with section headers, filtered by com.docker.compose.project label
- Enter inspects the selected element: service (first container), network (JSON), or volume (JSON); on project rows it drills down
- Add mergeLogReaders for multiplexed line-prefixed log streams