### PR TITLE
feat: add Compose lifecycle actions  for services and projects

### DIFF
--- a/app/help_texts.go
+++ b/app/help_texts.go
@@ -81,11 +81,18 @@ Visit <blue>http://moncho.github.io/dry/</> for more information.
 	<white>F1</>        Sorts the list
 	<white>F5</>        Refreshes the list
 	<white>%</>         Filters the list
+	<white>Ctrl+t</>    Stop project containers
+	<white>Ctrl+r</>    Restart project containers
+	<white>Ctrl+e</>    Remove project containers
 
 <yellow>Compose Services</>
 	<white>Esc</>       Back to projects
 	<white>F1</>        Sorts the list
 	<white>%</>         Filters the list
+	<white>Ctrl+s</>    Start service containers
+	<white>Ctrl+t</>    Stop service containers
+	<white>Ctrl+r</>    Restart service containers
+	<white>Ctrl+e</>    Remove service containers
 
 <yellow>Move around in lists</>
 	<white>ArrowUp</>   Moves the cursor one line up

--- a/app/keys.go
+++ b/app/keys.go
@@ -469,6 +469,7 @@ type composeProjectsKeyMap struct {
 	Sort, Refresh, Filter                                                 key.Binding
 	Monitor, Containers, Images, Nets, Vols, Nodes, Svcs, Stacks, Compose key.Binding
 	Enter                                                                 key.Binding
+	Stop, Restart, Remove                                                 key.Binding
 }
 
 var composeProjectsKeys = composeProjectsKeyMap{
@@ -487,13 +488,16 @@ var composeProjectsKeys = composeProjectsKeyMap{
 	Stacks:     key.NewBinding(key.WithKeys("7"), key.WithHelp("7", "stacks")),
 	Compose:    key.NewBinding(key.WithKeys("8"), key.WithHelp("8", "compose")),
 	Enter:      key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "services")),
+	Stop:       key.NewBinding(key.WithKeys("ctrl+t"), key.WithHelp("^t", "stop")),
+	Restart:    key.NewBinding(key.WithKeys("ctrl+r"), key.WithHelp("^r", "restart")),
+	Remove:     key.NewBinding(key.WithKeys("ctrl+e"), key.WithHelp("^e", "remove")),
 }
 
 func (k composeProjectsKeyMap) ShortHelp() []key.Binding {
 	return []key.Binding{
 		k.Help, k.Quit, k.Sort, k.Refresh, k.Filter,
 		k.Monitor, k.Containers, k.Images, k.Nets, k.Vols, k.Nodes, k.Svcs, k.Stacks, k.Compose,
-		k.Enter,
+		k.Enter, k.Stop, k.Restart, k.Remove,
 	}
 }
 
@@ -502,21 +506,26 @@ func (k composeProjectsKeyMap) FullHelp() [][]key.Binding { return [][]key.Bindi
 // --- compose services -----------------------------------------------------
 
 type composeServicesKeyMap struct {
-	Help, Quit    key.Binding
-	Sort, Filter  key.Binding
-	Back          key.Binding
+	Help, Quit                      key.Binding
+	Sort, Filter                    key.Binding
+	Back                            key.Binding
+	Start, Stop, Restart, Remove    key.Binding
 }
 
 var composeServicesKeys = composeServicesKeyMap{
-	Help:   key.NewBinding(key.WithKeys("h"), key.WithHelp("h", "help")),
-	Quit:   key.NewBinding(key.WithKeys("Q"), key.WithHelp("q", "quit")),
-	Sort:   key.NewBinding(key.WithKeys("f1"), key.WithHelp("F1", "sort")),
-	Filter: key.NewBinding(key.WithKeys("%"), key.WithHelp("%", "filter")),
-	Back:   key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+	Help:    key.NewBinding(key.WithKeys("h"), key.WithHelp("h", "help")),
+	Quit:    key.NewBinding(key.WithKeys("Q"), key.WithHelp("q", "quit")),
+	Sort:    key.NewBinding(key.WithKeys("f1"), key.WithHelp("F1", "sort")),
+	Filter:  key.NewBinding(key.WithKeys("%"), key.WithHelp("%", "filter")),
+	Back:    key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+	Start:   key.NewBinding(key.WithKeys("ctrl+s"), key.WithHelp("^s", "start")),
+	Stop:    key.NewBinding(key.WithKeys("ctrl+t"), key.WithHelp("^t", "stop")),
+	Restart: key.NewBinding(key.WithKeys("ctrl+r"), key.WithHelp("^r", "restart")),
+	Remove:  key.NewBinding(key.WithKeys("ctrl+e"), key.WithHelp("^e", "remove")),
 }
 
 func (k composeServicesKeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Help, k.Quit, k.Sort, k.Filter, k.Back}
+	return []key.Binding{k.Help, k.Quit, k.Sort, k.Filter, k.Back, k.Start, k.Stop, k.Restart, k.Remove}
 }
 
 func (k composeServicesKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{k.ShortHelp()} }

--- a/app/model.go
+++ b/app/model.go
@@ -889,6 +889,21 @@ func (m model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "f5":
 			return m, loadComposeProjectsCmd(m.daemon)
+		case "ctrl+t":
+			if p := m.composeProjects.SelectedProject(); p != nil {
+				return m.showPrompt(fmt.Sprintf("Stop project %s?", p.Name),
+					"compose-project-stop", p.Name), nil
+			}
+		case "ctrl+r":
+			if p := m.composeProjects.SelectedProject(); p != nil {
+				return m.showPrompt(fmt.Sprintf("Restart project %s?", p.Name),
+					"compose-project-restart", p.Name), nil
+			}
+		case "ctrl+e":
+			if p := m.composeProjects.SelectedProject(); p != nil {
+				return m.showPrompt(fmt.Sprintf("Remove project %s containers?", p.Name),
+					"compose-project-rm", p.Name), nil
+			}
 		}
 		var cmd tea.Cmd
 		m.composeProjects, cmd = m.composeProjects.Update(msg)
@@ -917,6 +932,26 @@ func (m model) handleKeyPress(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "f5":
 			return m, loadComposeServicesCmd(m.daemon, m.selectedProject)
+		case "ctrl+s":
+			if svc := m.composeServices.SelectedService(); svc != nil {
+				return m.showPrompt(fmt.Sprintf("Start service %s?", svc.Name),
+					"compose-start", svc.Project+"/"+svc.Name), nil
+			}
+		case "ctrl+t":
+			if svc := m.composeServices.SelectedService(); svc != nil {
+				return m.showPrompt(fmt.Sprintf("Stop service %s?", svc.Name),
+					"compose-stop", svc.Project+"/"+svc.Name), nil
+			}
+		case "ctrl+r":
+			if svc := m.composeServices.SelectedService(); svc != nil {
+				return m.showPrompt(fmt.Sprintf("Restart service %s?", svc.Name),
+					"compose-restart", svc.Project+"/"+svc.Name), nil
+			}
+		case "ctrl+e":
+			if svc := m.composeServices.SelectedService(); svc != nil {
+				return m.showPrompt(fmt.Sprintf("Remove service %s containers?", svc.Name),
+					"compose-rm", svc.Project+"/"+svc.Name), nil
+			}
 		}
 		var cmd tea.Cmd
 		m.composeServices, cmd = m.composeServices.Update(msg)
@@ -1383,6 +1418,38 @@ func (m model) executeContainerOp(tag, id string) tea.Cmd {
 		case "stack-rm":
 			err = daemon.StackRemove(id)
 			successMsg = fmt.Sprintf("Stack %s removed", id)
+		case "compose-start":
+			project, service, _ := strings.Cut(id, "/")
+			var report docker.ComposeServiceActionReport
+			report, err = daemon.ComposeServiceStart(project, service)
+			successMsg = report.Summary()
+		case "compose-stop":
+			project, service, _ := strings.Cut(id, "/")
+			var report docker.ComposeServiceActionReport
+			report, err = daemon.ComposeServiceStop(project, service)
+			successMsg = report.Summary()
+		case "compose-restart":
+			project, service, _ := strings.Cut(id, "/")
+			var report docker.ComposeServiceActionReport
+			report, err = daemon.ComposeServiceRestart(project, service)
+			successMsg = report.Summary()
+		case "compose-rm":
+			project, service, _ := strings.Cut(id, "/")
+			var report docker.ComposeServiceActionReport
+			report, err = daemon.ComposeServiceRemove(project, service)
+			successMsg = report.Summary()
+		case "compose-project-stop":
+			var report docker.ComposeServiceActionReport
+			report, err = daemon.ComposeProjectStop(id)
+			successMsg = report.Summary()
+		case "compose-project-restart":
+			var report docker.ComposeServiceActionReport
+			report, err = daemon.ComposeProjectRestart(id)
+			successMsg = report.Summary()
+		case "compose-project-rm":
+			var report docker.ComposeServiceActionReport
+			report, err = daemon.ComposeProjectRemove(id)
+			successMsg = report.Summary()
 		case "prune":
 			report, pruneErr := daemon.Prune()
 			if pruneErr != nil {

--- a/appui/compose/projects_model.go
+++ b/appui/compose/projects_model.go
@@ -210,13 +210,29 @@ func (m *ProjectsModel) RefreshTableStyles() {
 }
 
 func (m ProjectsModel) widgetHeader() string {
+	total := len(m.projects)
+	filtered := total
+	if m.table.FilterText() != "" {
+		filtered = m.countFilteredProjects()
+	}
 	return appui.RenderWidgetHeader(appui.WidgetHeaderOpts{
 		Icon:     "\U0001f433",
 		Title:    "Compose Projects",
-		Total:    m.table.TotalRowCount(),
-		Filtered: m.table.RowCount(),
+		Total:    total,
+		Filtered: filtered,
 		Filter:   m.table.FilterText(),
 		Width:    m.table.Width(),
 		Accent:   appui.DryTheme.Info,
 	})
+}
+
+// countFilteredProjects counts how many project header rows survive the current filter.
+func (m ProjectsModel) countFilteredProjects() int {
+	count := 0
+	for _, row := range m.table.FilteredRows() {
+		if _, ok := row.(projectHeaderRow); ok {
+			count++
+		}
+	}
+	return count
 }

--- a/appui/compose/services_model.go
+++ b/appui/compose/services_model.go
@@ -91,9 +91,10 @@ type ServicesLoadedMsg struct {
 
 // ServicesModel is the Compose project resources view.
 type ServicesModel struct {
-	table   appui.TableModel
-	filter  appui.FilterInputModel
-	project string
+	table        appui.TableModel
+	filter       appui.FilterInputModel
+	project      string
+	serviceCount int
 }
 
 // NewServicesModel creates a compose services list model.
@@ -129,6 +130,7 @@ func (m *ServicesModel) SetSize(w, h int) {
 // SetServices replaces the resource list with services, networks, and volumes.
 func (m *ServicesModel) SetServices(services []docker.ComposeService, networks []docker.ComposeNetwork, volumes []docker.ComposeVolume, project string) {
 	m.project = project
+	m.serviceCount = len(services)
 	var rows []appui.TableRow
 
 	if len(services) > 0 {
@@ -220,11 +222,15 @@ func (m ServicesModel) View() string {
 	if m.project != "" {
 		title = fmt.Sprintf("Compose: %s", m.project)
 	}
+	filtered := m.serviceCount
+	if m.table.FilterText() != "" {
+		filtered = m.countFilteredServices()
+	}
 	header := appui.RenderWidgetHeader(appui.WidgetHeaderOpts{
 		Icon:     "\U0001f433",
 		Title:    title,
-		Total:    m.table.TotalRowCount(),
-		Filtered: m.table.RowCount(),
+		Total:    m.serviceCount,
+		Filtered: filtered,
 		Filter:   m.table.FilterText(),
 		Width:    m.table.Width(),
 		Accent:   appui.DryTheme.Info,
@@ -234,6 +240,17 @@ func (m ServicesModel) View() string {
 		result += "\n" + filterView
 	}
 	return result
+}
+
+// countFilteredServices counts how many service rows survive the current filter.
+func (m ServicesModel) countFilteredServices() int {
+	count := 0
+	for _, row := range m.table.FilteredRows() {
+		if _, ok := row.(serviceRow); ok {
+			count++
+		}
+	}
+	return count
 }
 
 // RefreshTableStyles re-applies theme styles to the inner table.

--- a/appui/table_model.go
+++ b/appui/table_model.go
@@ -126,6 +126,11 @@ func (m TableModel) TotalRowCount() int {
 	return len(m.rows)
 }
 
+// FilteredRows returns the currently visible (filtered) rows.
+func (m TableModel) FilteredRows() []TableRow {
+	return m.filtered
+}
+
 // FilterText returns the active filter string.
 func (m TableModel) FilterText() string {
 	return m.filterText

--- a/docker/api.go
+++ b/docker/api.go
@@ -29,6 +29,17 @@ type ComposeAPI interface {
 	ComposeServices(project string) []ComposeService
 }
 
+// ComposeActionsAPI defines lifecycle actions for Docker Compose services and projects.
+type ComposeActionsAPI interface {
+	ComposeServiceStart(project, service string) (ComposeServiceActionReport, error)
+	ComposeServiceStop(project, service string) (ComposeServiceActionReport, error)
+	ComposeServiceRestart(project, service string) (ComposeServiceActionReport, error)
+	ComposeServiceRemove(project, service string) (ComposeServiceActionReport, error)
+	ComposeProjectStop(project string) (ComposeServiceActionReport, error)
+	ComposeProjectRestart(project string) (ComposeServiceActionReport, error)
+	ComposeProjectRemove(project string) (ComposeServiceActionReport, error)
+}
+
 // ContainerDaemon describes what is expected from the container daemon
 type ContainerDaemon interface {
 	ContainerAPI
@@ -37,6 +48,7 @@ type ContainerDaemon interface {
 	VolumesAPI
 	SwarmAPI
 	ComposeAPI
+	ComposeActionsAPI
 	ContainerRuntime
 	DiskUsage() (types.DiskUsage, error)
 	DockerEnv() Env
@@ -62,6 +74,7 @@ type ContainerAPI interface {
 	Logs(id string, since string, withTimeStamp bool) (io.ReadCloser, error)
 	RemoveAllStoppedContainers() (int, error)
 	RestartContainer(id string) error
+	StartContainer(id string) error
 	StopContainer(id string) error
 }
 

--- a/docker/compose_actions.go
+++ b/docker/compose_actions.go
@@ -1,0 +1,283 @@
+package docker
+
+import (
+	"fmt"
+	"sort"
+)
+
+// ComposeServiceActionReport summarises the result of a lifecycle action on a
+// Compose service's containers.
+type ComposeServiceActionReport struct {
+	Project   string
+	Service   string
+	Action    string // "start", "stop", "restart", "remove"
+	Targeted  int
+	Attempted int
+	Succeeded int
+	Failed    int
+	Skipped   int
+	Errors    []string
+}
+
+// Summary formats the report as a one-line status message.
+func (r ComposeServiceActionReport) Summary() string {
+	action := r.Action
+	if len(action) > 0 {
+		action = string(action[0]-32) + action[1:]
+	}
+	target := r.Project + "/" + r.Service
+	if r.Service == "" {
+		target = r.Project
+	}
+	base := fmt.Sprintf("%s %s: %d targeted, %d succeeded",
+		action, target, r.Targeted, r.Succeeded)
+	if r.Skipped > 0 {
+		base += fmt.Sprintf(", %d skipped", r.Skipped)
+	}
+	if r.Failed > 0 {
+		base += fmt.Sprintf(", %d failed", r.Failed)
+	}
+	return base
+}
+
+// composeServiceContainers returns all containers belonging to the given
+// Compose project+service, sorted by name then ID for deterministic ordering.
+func composeServiceContainers(daemon *DockerDaemon, project, service string) []*Container {
+	all := daemon.Containers(nil, NoSort)
+	var matched []*Container
+	for _, c := range all {
+		if c.Labels["com.docker.compose.project"] != project {
+			continue
+		}
+		if c.Labels["com.docker.compose.service"] != service {
+			continue
+		}
+		if c.Labels["com.docker.compose.oneoff"] == "True" {
+			continue
+		}
+		matched = append(matched, c)
+	}
+	sort.Slice(matched, func(i, j int) bool {
+		ni := ""
+		nj := ""
+		if len(matched[i].Names) > 0 {
+			ni = matched[i].Names[0]
+		}
+		if len(matched[j].Names) > 0 {
+			nj = matched[j].Names[0]
+		}
+		if ni != nj {
+			return ni < nj
+		}
+		return matched[i].ID < matched[j].ID
+	})
+	return matched
+}
+
+// ComposeServiceStart starts non-running containers of the given Compose service.
+func (daemon *DockerDaemon) ComposeServiceStart(project, service string) (ComposeServiceActionReport, error) {
+	targets := composeServiceContainers(daemon, project, service)
+	report := ComposeServiceActionReport{
+		Project:  project,
+		Service:  service,
+		Action:   "start",
+		Targeted: len(targets),
+	}
+	for _, c := range targets {
+		if IsContainerRunning(c) {
+			report.Skipped++
+			continue
+		}
+		report.Attempted++
+		if err := daemon.StartContainer(c.ID); err != nil {
+			report.Failed++
+			report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", c.ID[:12], err))
+		} else {
+			report.Succeeded++
+		}
+	}
+	if err := daemon.refreshAndWait(); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+// ComposeServiceStop stops running containers of the given Compose service.
+func (daemon *DockerDaemon) ComposeServiceStop(project, service string) (ComposeServiceActionReport, error) {
+	targets := composeServiceContainers(daemon, project, service)
+	report := ComposeServiceActionReport{
+		Project:  project,
+		Service:  service,
+		Action:   "stop",
+		Targeted: len(targets),
+	}
+	for _, c := range targets {
+		if !IsContainerRunning(c) {
+			report.Skipped++
+			continue
+		}
+		report.Attempted++
+		if err := daemon.StopContainer(c.ID); err != nil {
+			report.Failed++
+			report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", c.ID[:12], err))
+		} else {
+			report.Succeeded++
+		}
+	}
+	if err := daemon.refreshAndWait(); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+// ComposeServiceRestart restarts all containers of the given Compose service.
+func (daemon *DockerDaemon) ComposeServiceRestart(project, service string) (ComposeServiceActionReport, error) {
+	targets := composeServiceContainers(daemon, project, service)
+	report := ComposeServiceActionReport{
+		Project:  project,
+		Service:  service,
+		Action:   "restart",
+		Targeted: len(targets),
+	}
+	for _, c := range targets {
+		report.Attempted++
+		if err := daemon.RestartContainer(c.ID); err != nil {
+			report.Failed++
+			report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", c.ID[:12], err))
+		} else {
+			report.Succeeded++
+		}
+	}
+	if err := daemon.refreshAndWait(); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+// ComposeServiceRemove force-removes all containers of the given Compose service.
+func (daemon *DockerDaemon) ComposeServiceRemove(project, service string) (ComposeServiceActionReport, error) {
+	targets := composeServiceContainers(daemon, project, service)
+	report := ComposeServiceActionReport{
+		Project:  project,
+		Service:  service,
+		Action:   "remove",
+		Targeted: len(targets),
+	}
+	for _, c := range targets {
+		report.Attempted++
+		if err := daemon.Rm(c.ID); err != nil {
+			report.Failed++
+			report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", c.ID[:12], err))
+		} else {
+			report.Succeeded++
+		}
+	}
+	if err := daemon.refreshAndWait(); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+// composeProjectContainers returns all containers belonging to the given
+// Compose project, sorted by name then ID for deterministic ordering.
+func composeProjectContainers(daemon *DockerDaemon, project string) []*Container {
+	all := daemon.Containers(nil, NoSort)
+	var matched []*Container
+	for _, c := range all {
+		if c.Labels["com.docker.compose.project"] != project {
+			continue
+		}
+		if c.Labels["com.docker.compose.oneoff"] == "True" {
+			continue
+		}
+		matched = append(matched, c)
+	}
+	sort.Slice(matched, func(i, j int) bool {
+		ni := ""
+		nj := ""
+		if len(matched[i].Names) > 0 {
+			ni = matched[i].Names[0]
+		}
+		if len(matched[j].Names) > 0 {
+			nj = matched[j].Names[0]
+		}
+		if ni != nj {
+			return ni < nj
+		}
+		return matched[i].ID < matched[j].ID
+	})
+	return matched
+}
+
+// ComposeProjectStop stops running containers of the given Compose project.
+func (daemon *DockerDaemon) ComposeProjectStop(project string) (ComposeServiceActionReport, error) {
+	targets := composeProjectContainers(daemon, project)
+	report := ComposeServiceActionReport{
+		Project:  project,
+		Action:   "stop",
+		Targeted: len(targets),
+	}
+	for _, c := range targets {
+		if !IsContainerRunning(c) {
+			report.Skipped++
+			continue
+		}
+		report.Attempted++
+		if err := daemon.StopContainer(c.ID); err != nil {
+			report.Failed++
+			report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", c.ID[:12], err))
+		} else {
+			report.Succeeded++
+		}
+	}
+	if err := daemon.refreshAndWait(); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+// ComposeProjectRestart restarts all containers of the given Compose project.
+func (daemon *DockerDaemon) ComposeProjectRestart(project string) (ComposeServiceActionReport, error) {
+	targets := composeProjectContainers(daemon, project)
+	report := ComposeServiceActionReport{
+		Project:  project,
+		Action:   "restart",
+		Targeted: len(targets),
+	}
+	for _, c := range targets {
+		report.Attempted++
+		if err := daemon.RestartContainer(c.ID); err != nil {
+			report.Failed++
+			report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", c.ID[:12], err))
+		} else {
+			report.Succeeded++
+		}
+	}
+	if err := daemon.refreshAndWait(); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+// ComposeProjectRemove force-removes all containers of the given Compose project.
+func (daemon *DockerDaemon) ComposeProjectRemove(project string) (ComposeServiceActionReport, error) {
+	targets := composeProjectContainers(daemon, project)
+	report := ComposeServiceActionReport{
+		Project:  project,
+		Action:   "remove",
+		Targeted: len(targets),
+	}
+	for _, c := range targets {
+		report.Attempted++
+		if err := daemon.Rm(c.ID); err != nil {
+			report.Failed++
+			report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", c.ID[:12], err))
+		} else {
+			report.Succeeded++
+		}
+	}
+	if err := daemon.refreshAndWait(); err != nil {
+		return report, err
+	}
+	return report, nil
+}

--- a/docker/compose_actions_test.go
+++ b/docker/compose_actions_test.go
@@ -1,0 +1,472 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	dockerAPI "github.com/docker/docker/client"
+)
+
+// composeTestClient is a mock Docker API client for compose action tests.
+type composeTestClient struct {
+	dockerAPI.APIClient
+	startErr   map[string]error
+	stopErr    map[string]error
+	restartErr map[string]error
+	removeErr  map[string]error
+}
+
+func (c *composeTestClient) ContainerStart(ctx context.Context, id string, opts container.StartOptions) error {
+	if c.startErr != nil {
+		if err, ok := c.startErr[id]; ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *composeTestClient) ContainerStop(ctx context.Context, id string, opts container.StopOptions) error {
+	if c.stopErr != nil {
+		if err, ok := c.stopErr[id]; ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *composeTestClient) ContainerRestart(ctx context.Context, id string, opts container.StopOptions) error {
+	if c.restartErr != nil {
+		if err, ok := c.restartErr[id]; ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *composeTestClient) ContainerRemove(ctx context.Context, id string, opts container.RemoveOptions) error {
+	if c.removeErr != nil {
+		if err, ok := c.removeErr[id]; ok {
+			return err
+		}
+	}
+	return nil
+}
+
+// ContainerList is needed for refreshAndWait → NewDockerContainerStore.
+func (c *composeTestClient) ContainerList(ctx context.Context, opts container.ListOptions) ([]container.Summary, error) {
+	return nil, nil
+}
+
+// simpleStore implements ContainerStore for test pre-population.
+type simpleStore struct {
+	containers []*Container
+}
+
+func (s *simpleStore) Get(id string) *Container {
+	for _, c := range s.containers {
+		if c.ID == id {
+			return c
+		}
+	}
+	return nil
+}
+func (s *simpleStore) List() []*Container       { return s.containers }
+func (s *simpleStore) Remove(id string)         {}
+func (s *simpleStore) Size() int                { return len(s.containers) }
+
+func newTestDaemon(containers []*Container, client *composeTestClient) *DockerDaemon {
+	return &DockerDaemon{
+		client: client,
+		s:      &simpleStore{containers: containers},
+	}
+}
+
+func TestComposeServiceContainers_MatchesByLabels(t *testing.T) {
+	containers := []*Container{
+		makeContainer("aaa111222333", "Up 1h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+		makeContainer("bbb111222333", "Exited (0)", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "db",
+		}, "pg:15"),
+		makeContainer("ccc111222333", "Up 2h", map[string]string{
+			"com.docker.compose.project": "other",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+		// One-off excluded
+		makeContainer("ddd111222333", "Up 1h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+			"com.docker.compose.oneoff":  "True",
+		}, "api:latest"),
+	}
+	daemon := newTestDaemon(containers, &composeTestClient{})
+	matched := composeServiceContainers(daemon, "web", "api")
+	if len(matched) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(matched))
+	}
+	if matched[0].ID != "aaa111222333" {
+		t.Errorf("expected container aaa111222333, got %s", matched[0].ID)
+	}
+}
+
+func TestComposeServiceStart_SkipsRunning(t *testing.T) {
+	containers := []*Container{
+		makeContainer("run111222333", "Up 1h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+		makeContainer("stp111222333", "Exited (0)", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+	}
+	daemon := newTestDaemon(containers, &composeTestClient{})
+	report, err := daemon.ComposeServiceStart("web", "api")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Targeted != 2 {
+		t.Errorf("expected 2 targeted, got %d", report.Targeted)
+	}
+	if report.Skipped != 1 {
+		t.Errorf("expected 1 skipped (running), got %d", report.Skipped)
+	}
+	if report.Succeeded != 1 {
+		t.Errorf("expected 1 succeeded, got %d", report.Succeeded)
+	}
+	if report.Failed != 0 {
+		t.Errorf("expected 0 failed, got %d", report.Failed)
+	}
+}
+
+func TestComposeServiceStop_SkipsStopped(t *testing.T) {
+	containers := []*Container{
+		makeContainer("run111222333", "Up 1h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+		makeContainer("stp111222333", "Exited (0)", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+	}
+	daemon := newTestDaemon(containers, &composeTestClient{})
+	report, err := daemon.ComposeServiceStop("web", "api")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Targeted != 2 {
+		t.Errorf("expected 2 targeted, got %d", report.Targeted)
+	}
+	if report.Skipped != 1 {
+		t.Errorf("expected 1 skipped (stopped), got %d", report.Skipped)
+	}
+	if report.Succeeded != 1 {
+		t.Errorf("expected 1 succeeded, got %d", report.Succeeded)
+	}
+}
+
+func TestComposeServiceRestart_AllContainers(t *testing.T) {
+	containers := []*Container{
+		makeContainer("aaa111222333", "Up 1h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+		makeContainer("bbb111222333", "Exited (0)", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+	}
+	daemon := newTestDaemon(containers, &composeTestClient{})
+	report, err := daemon.ComposeServiceRestart("web", "api")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Targeted != 2 {
+		t.Errorf("expected 2 targeted, got %d", report.Targeted)
+	}
+	if report.Skipped != 0 {
+		t.Errorf("expected 0 skipped, got %d", report.Skipped)
+	}
+	if report.Succeeded != 2 {
+		t.Errorf("expected 2 succeeded, got %d", report.Succeeded)
+	}
+}
+
+func TestComposeServiceRemove_AllContainers(t *testing.T) {
+	containers := []*Container{
+		makeContainer("aaa111222333", "Up 1h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+		makeContainer("bbb111222333", "Exited (0)", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+	}
+	daemon := newTestDaemon(containers, &composeTestClient{})
+	report, err := daemon.ComposeServiceRemove("web", "api")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Targeted != 2 {
+		t.Errorf("expected 2 targeted, got %d", report.Targeted)
+	}
+	if report.Succeeded != 2 {
+		t.Errorf("expected 2 succeeded, got %d", report.Succeeded)
+	}
+	if report.Action != "remove" {
+		t.Errorf("expected action 'remove', got %q", report.Action)
+	}
+}
+
+func TestComposeServiceStart_PartialFailure(t *testing.T) {
+	containers := []*Container{
+		makeContainer("ok1111222333", "Exited (0)", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+		makeContainer("fail11222333", "Exited (1)", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+	}
+	client := &composeTestClient{
+		startErr: map[string]error{
+			"fail11222333": errors.New("cannot start"),
+		},
+	}
+	daemon := newTestDaemon(containers, client)
+	report, err := daemon.ComposeServiceStart("web", "api")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Succeeded != 1 {
+		t.Errorf("expected 1 succeeded, got %d", report.Succeeded)
+	}
+	if report.Failed != 1 {
+		t.Errorf("expected 1 failed, got %d", report.Failed)
+	}
+	if len(report.Errors) != 1 {
+		t.Errorf("expected 1 error message, got %d", len(report.Errors))
+	}
+}
+
+func TestComposeServiceActionReport_Summary(t *testing.T) {
+	report := ComposeServiceActionReport{
+		Project:   "web",
+		Service:   "api",
+		Action:    "stop",
+		Targeted:  3,
+		Succeeded: 2,
+		Skipped:   1,
+		Failed:    0,
+	}
+	summary := report.Summary()
+	if summary != "Stop web/api: 3 targeted, 2 succeeded, 1 skipped" {
+		t.Errorf("unexpected summary: %q", summary)
+	}
+
+	report.Failed = 1
+	summary = report.Summary()
+	if summary != "Stop web/api: 3 targeted, 2 succeeded, 1 skipped, 1 failed" {
+		t.Errorf("unexpected summary with failures: %q", summary)
+	}
+}
+
+func TestComposeServiceContainers_DeterministicOrder(t *testing.T) {
+	containers := []*Container{
+		{Summary: container.Summary{
+			ID:     "zzz111222333",
+			Names:  []string{"/web-api-2"},
+			Status: "Up 1h",
+			Labels: map[string]string{
+				"com.docker.compose.project": "web",
+				"com.docker.compose.service": "api",
+			},
+		}},
+		{Summary: container.Summary{
+			ID:     "aaa111222333",
+			Names:  []string{"/web-api-1"},
+			Status: "Up 1h",
+			Labels: map[string]string{
+				"com.docker.compose.project": "web",
+				"com.docker.compose.service": "api",
+			},
+		}},
+	}
+	daemon := newTestDaemon(containers, &composeTestClient{})
+	matched := composeServiceContainers(daemon, "web", "api")
+	if len(matched) != 2 {
+		t.Fatalf("expected 2 containers, got %d", len(matched))
+	}
+	// Sorted by name: /web-api-1 before /web-api-2
+	if matched[0].ID != "aaa111222333" {
+		t.Errorf("expected first container aaa111222333, got %s", matched[0].ID)
+	}
+	if matched[1].ID != "zzz111222333" {
+		t.Errorf("expected second container zzz111222333, got %s", matched[1].ID)
+	}
+}
+
+// --- Project-level action tests ---
+
+func TestComposeProjectContainers_MatchesAllServices(t *testing.T) {
+	containers := []*Container{
+		makeContainer("aaa111222333", "Up 1h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+		makeContainer("bbb111222333", "Up 2h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "db",
+		}, "pg:15"),
+		makeContainer("ccc111222333", "Up 1h", map[string]string{
+			"com.docker.compose.project": "other",
+			"com.docker.compose.service": "svc",
+		}, "svc:latest"),
+		// One-off excluded
+		makeContainer("ddd111222333", "Up 1h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+			"com.docker.compose.oneoff":  "True",
+		}, "api:latest"),
+	}
+	daemon := newTestDaemon(containers, &composeTestClient{})
+	matched := composeProjectContainers(daemon, "web")
+	if len(matched) != 2 {
+		t.Fatalf("expected 2 containers, got %d", len(matched))
+	}
+}
+
+func TestComposeProjectStop_SkipsStopped(t *testing.T) {
+	containers := []*Container{
+		makeContainer("run111222333", "Up 1h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+		makeContainer("stp111222333", "Exited (0)", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "db",
+		}, "pg:15"),
+	}
+	daemon := newTestDaemon(containers, &composeTestClient{})
+	report, err := daemon.ComposeProjectStop("web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Targeted != 2 {
+		t.Errorf("expected 2 targeted, got %d", report.Targeted)
+	}
+	if report.Skipped != 1 {
+		t.Errorf("expected 1 skipped, got %d", report.Skipped)
+	}
+	if report.Succeeded != 1 {
+		t.Errorf("expected 1 succeeded, got %d", report.Succeeded)
+	}
+	if report.Service != "" {
+		t.Errorf("expected empty service, got %q", report.Service)
+	}
+}
+
+func TestComposeProjectRestart_AllContainers(t *testing.T) {
+	containers := []*Container{
+		makeContainer("aaa111222333", "Up 1h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+		makeContainer("bbb111222333", "Exited (0)", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "db",
+		}, "pg:15"),
+	}
+	daemon := newTestDaemon(containers, &composeTestClient{})
+	report, err := daemon.ComposeProjectRestart("web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Targeted != 2 {
+		t.Errorf("expected 2 targeted, got %d", report.Targeted)
+	}
+	if report.Succeeded != 2 {
+		t.Errorf("expected 2 succeeded, got %d", report.Succeeded)
+	}
+}
+
+func TestComposeProjectRemove_AllContainers(t *testing.T) {
+	containers := []*Container{
+		makeContainer("aaa111222333", "Up 1h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+		makeContainer("bbb111222333", "Up 2h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "db",
+		}, "pg:15"),
+	}
+	daemon := newTestDaemon(containers, &composeTestClient{})
+	report, err := daemon.ComposeProjectRemove("web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Targeted != 2 {
+		t.Errorf("expected 2 targeted, got %d", report.Targeted)
+	}
+	if report.Succeeded != 2 {
+		t.Errorf("expected 2 succeeded, got %d", report.Succeeded)
+	}
+	if report.Action != "remove" {
+		t.Errorf("expected action 'remove', got %q", report.Action)
+	}
+}
+
+func TestComposeProjectStop_PartialFailure(t *testing.T) {
+	containers := []*Container{
+		makeContainer("ok1111222333", "Up 1h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "api",
+		}, "api:latest"),
+		makeContainer("fail11222333", "Up 2h", map[string]string{
+			"com.docker.compose.project": "web",
+			"com.docker.compose.service": "db",
+		}, "pg:15"),
+	}
+	client := &composeTestClient{
+		stopErr: map[string]error{
+			"fail11222333": errors.New("cannot stop"),
+		},
+	}
+	daemon := newTestDaemon(containers, client)
+	report, err := daemon.ComposeProjectStop("web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Succeeded != 1 {
+		t.Errorf("expected 1 succeeded, got %d", report.Succeeded)
+	}
+	if report.Failed != 1 {
+		t.Errorf("expected 1 failed, got %d", report.Failed)
+	}
+	if len(report.Errors) != 1 {
+		t.Errorf("expected 1 error message, got %d", len(report.Errors))
+	}
+}
+
+func TestComposeProjectActionReport_Summary(t *testing.T) {
+	report := ComposeServiceActionReport{
+		Project:   "web",
+		Action:    "stop",
+		Targeted:  4,
+		Succeeded: 3,
+		Skipped:   1,
+	}
+	summary := report.Summary()
+	if summary != "Stop web: 4 targeted, 3 succeeded, 1 skipped" {
+		t.Errorf("unexpected project-level summary: %q", summary)
+	}
+}

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -447,6 +447,16 @@ func (daemon *DockerDaemon) store() ContainerStore {
 	return daemon.s
 }
 
+// StartContainer starts the container with the given id
+func (daemon *DockerDaemon) StartContainer(id string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultOperationTimeout)
+	defer cancel()
+	if err := daemon.client.ContainerStart(ctx, id, container.StartOptions{}); err != nil {
+		return err
+	}
+	return daemon.refreshAndWait()
+}
+
 // StopContainer stops the container with the given id
 func (daemon *DockerDaemon) StopContainer(id string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultOperationTimeout)

--- a/mocks/docker_daemon.go
+++ b/mocks/docker_daemon.go
@@ -370,6 +370,11 @@ func (_m *DockerDaemonMock) ServiceUpdate(id string) error {
 	return nil
 }
 
+// StartContainer provides a mock function with given fields: id
+func (_m *DockerDaemonMock) StartContainer(id string) error {
+	return nil
+}
+
 // StopContainer provides a mock function with given fields: id
 func (_m *DockerDaemonMock) StopContainer(id string) error {
 	return nil
@@ -467,4 +472,39 @@ func (_m *DockerDaemonMock) VolumeRemove(ctx context.Context, volumeID string, f
 // VolumeRemoveAll mock
 func (_m *DockerDaemonMock) VolumeRemoveAll(ctx context.Context) (int, error) {
 	return 0, nil
+}
+
+// ComposeServiceStart mock
+func (_m *DockerDaemonMock) ComposeServiceStart(project, service string) (drydocker.ComposeServiceActionReport, error) {
+	return drydocker.ComposeServiceActionReport{}, nil
+}
+
+// ComposeServiceStop mock
+func (_m *DockerDaemonMock) ComposeServiceStop(project, service string) (drydocker.ComposeServiceActionReport, error) {
+	return drydocker.ComposeServiceActionReport{}, nil
+}
+
+// ComposeServiceRestart mock
+func (_m *DockerDaemonMock) ComposeServiceRestart(project, service string) (drydocker.ComposeServiceActionReport, error) {
+	return drydocker.ComposeServiceActionReport{}, nil
+}
+
+// ComposeServiceRemove mock
+func (_m *DockerDaemonMock) ComposeServiceRemove(project, service string) (drydocker.ComposeServiceActionReport, error) {
+	return drydocker.ComposeServiceActionReport{}, nil
+}
+
+// ComposeProjectStop mock
+func (_m *DockerDaemonMock) ComposeProjectStop(project string) (drydocker.ComposeServiceActionReport, error) {
+	return drydocker.ComposeServiceActionReport{}, nil
+}
+
+// ComposeProjectRestart mock
+func (_m *DockerDaemonMock) ComposeProjectRestart(project string) (drydocker.ComposeServiceActionReport, error) {
+	return drydocker.ComposeServiceActionReport{}, nil
+}
+
+// ComposeProjectRemove mock
+func (_m *DockerDaemonMock) ComposeProjectRemove(project string) (drydocker.ComposeServiceActionReport, error) {
+	return drydocker.ComposeServiceActionReport{}, nil
 }


### PR DESCRIPTION

Service-level actions (Ctrl+s/t/r/e) in Compose Services view and project-level actions (Ctrl+t/r/e) in Compose Projects view let users manage containers without leaving dry. Each action shows a confirmation prompt, operates on matching containers, and reports results in the status bar. Also fixes widget headers to count projects/services correctly instead of counting all table rows.