### PR TITLE
Arch install command should be yay not yaourt

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ brew install dry
 
 #### Arch Linux
 
-```yaourt -S dry-bin```
+```yay -S dry-bin```
 
 ### Usage
 


### PR DESCRIPTION
`yaourt` is not used anymore and `yay` is the most popular Arch AUR helper.