### PR TITLE
fix: workspace monitor pane layout and chart improvements

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -31,6 +31,17 @@ import (
 
 const monitorChartWindow = 3 * time.Minute
 
+// Monitor chart layout constants.
+const (
+	chartGap       = 4  // horizontal gap between side-by-side charts
+	chartPadding   = 4  // horizontal padding within each chart panel
+	minChartWidth  = 20 // minimum chart render width
+	maxChartWidth  = 56 // maximum chart render width
+	minChartHeight = 3  // minimum chart render height
+	chartOverhead  = 4  // non-chart lines: legend + blank + title + detail
+	chartHeightPct = 60 // percentage of available body height used for chart
+)
+
 // demuxedReadCloser wraps a pipe reader and closes the underlying Docker stream.
 type demuxedReadCloser struct {
 	io.Reader
@@ -1152,28 +1163,29 @@ func loadWorkspaceMonitorDetailsFromContext(ctx workspaceContext, chartWidth, ch
 func workspaceMonitorDetailContent(ctx workspaceContext, chartWidth, chartHeight int) string {
 	cpuHistory := ctx.monitorHistory(ctx.monitorCPUHistory, ctx.monitorCPU)
 	memHistory := ctx.monitorHistory(ctx.monitorMemHistory, ctx.monitorPct)
-	sections := []string{
-		monitorLegendLine(),
-		monitorHistorySection(
-			"CPU",
-			cpuHistory,
-			fmt.Sprintf("now %5.1f%%", ctx.monitorCPU),
-			appui.DryTheme.Info,
-			chartWidth,
-			chartHeight,
-			runes.ArcLineStyle,
-		),
-		monitorHistorySection(
-			"Memory",
-			memHistory,
-			fmt.Sprintf("%s / %s  (%5.1f%%)", units.BytesSize(ctx.monitorMem), units.BytesSize(ctx.monitorMax), ctx.monitorPct),
-			appui.DryTheme.Secondary,
-			chartWidth,
-			chartHeight,
-			runes.ThinLineStyle,
-		),
-	}
-	return strings.Join(sections, "\n\n")
+	halfWidth := chartWidth / 2
+	cpu := monitorHistorySection(
+		"CPU",
+		cpuHistory,
+		fmt.Sprintf("now %5.1f%%", ctx.monitorCPU),
+		appui.DryTheme.Info,
+		halfWidth,
+		chartHeight,
+		runes.ArcLineStyle,
+	)
+	mem := monitorHistorySection(
+		"Memory",
+		memHistory,
+		fmt.Sprintf("%s / %s  (%5.1f%%)", units.BytesSize(ctx.monitorMem), units.BytesSize(ctx.monitorMax), ctx.monitorPct),
+		appui.DryTheme.Secondary,
+		halfWidth,
+		chartHeight,
+		runes.ThinLineStyle,
+	)
+	indent := lipgloss.NewStyle().PaddingLeft(2)
+	cpuPane := lipgloss.PlaceHorizontal(halfWidth, lipgloss.Left, indent.Render(cpu))
+	memPane := lipgloss.PlaceHorizontal(halfWidth, lipgloss.Left, indent.Render(mem))
+	return monitorLegendLine() + "\n\n" + lipgloss.JoinHorizontal(lipgloss.Top, cpuPane, memPane)
 }
 
 func (ctx workspaceContext) monitorHistory(history []appui.MonitorPoint, current float64) []appui.MonitorPoint {
@@ -1186,7 +1198,7 @@ func (ctx workspaceContext) monitorHistory(history []appui.MonitorPoint, current
 func monitorHistorySection(title string, samples []appui.MonitorPoint, detail string, accent color.Color, chartWidth, bodyHeight int, lineStyle runes.LineStyle) string {
 	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(appui.DryTheme.Fg)
 	detailStyle := lipgloss.NewStyle().Foreground(appui.DryTheme.FgMuted)
-	graph := monitorHistoryChart(samples, monitorChartWidth(chartWidth), monitorChartHeight(chartWidth, bodyHeight), accent, lineStyle)
+	graph := monitorHistoryChart(samples, monitorChartWidth(chartWidth), monitorChartHeight(bodyHeight), accent, lineStyle)
 	return strings.Join([]string{
 		labelStyle.Render(title),
 		detailStyle.Render(detail),
@@ -1327,35 +1339,20 @@ func colorToHex(c color.Color) string {
 	return fmt.Sprintf("#%02x%02x%02x", r>>8, g>>8, b>>8)
 }
 
-func monitorChartWidth(activityWidth int) int {
-	if activityWidth <= 0 {
-		return 56
+func monitorChartWidth(halfWidth int) int {
+	if halfWidth <= 0 {
+		return minChartWidth + chartPadding
 	}
-	width := activityWidth - 4
-	if width < 40 {
-		width = 40
-	}
-	if width > 96 {
-		width = 96
-	}
-	return width
+	return max(minChartWidth, min(halfWidth-chartPadding, maxChartWidth))
 }
 
-func monitorChartHeight(activityWidth, bodyHeight int) int {
-	height := 8
-	if activityWidth >= 110 {
-		height = 12
-	} else if activityWidth >= 80 {
-		height = 10
+func monitorChartHeight(bodyHeight int) int {
+	available := bodyHeight - chartOverhead
+	height := max(minChartHeight, available*chartHeightPct/100)
+	if height > available {
+		height = available
 	}
-	maxFit := (bodyHeight - 5) / 2
-	if maxFit < 3 {
-		maxFit = 3
-	}
-	if height > maxFit {
-		height = maxFit
-	}
-	return height
+	return max(minChartHeight, height)
 }
 
 func loadWorkspaceNodeInspectCmd(daemon docker.ContainerDaemon, id string) tea.Cmd {

--- a/app/commands_test.go
+++ b/app/commands_test.go
@@ -93,13 +93,13 @@ func TestLoadWorkspaceMonitorDetailsStatusShowsCollectedDuration(t *testing.T) {
 }
 
 func TestMonitorChartWidthUsesAvailableActivityWidth(t *testing.T) {
-	if got, want := monitorChartWidth(120), 96; got != want {
-		t.Fatalf("expected wide activity chart width %d, got %d", want, got)
+	if got, want := monitorChartWidth(60), 56; got != want {
+		t.Fatalf("expected wide half-width chart width %d, got %d", want, got)
 	}
-	if got, want := monitorChartWidth(72), 68; got != want {
-		t.Fatalf("expected medium activity chart width %d, got %d", want, got)
+	if got, want := monitorChartWidth(36), 32; got != want {
+		t.Fatalf("expected medium half-width chart width %d, got %d", want, got)
 	}
-	if got, want := monitorChartWidth(20), 40; got != want {
+	if got, want := monitorChartWidth(10), 20; got != want {
 		t.Fatalf("expected minimum chart width %d, got %d", want, got)
 	}
 }
@@ -130,13 +130,14 @@ func TestMonitorChartYRangeTracksObservedValues(t *testing.T) {
 }
 
 func TestMonitorChartHeightFitsAvailableBody(t *testing.T) {
-	if got, want := monitorChartHeight(120, 18), 6; got != want {
-		t.Fatalf("expected chart height %d to fit body, got %d", want, got)
+	// Proportional: chartHeightPct of (bodyHeight - chartOverhead), clamped to [minChartHeight, available].
+	if got, want := monitorChartHeight(12), 4; got != want {
+		t.Fatalf("expected chart height %d for moderate body, got %d", want, got)
 	}
-	if got, want := monitorChartHeight(120, 30), 12; got != want {
+	if got, want := monitorChartHeight(20), 9; got != want {
 		t.Fatalf("expected taller chart height %d for roomy pane, got %d", want, got)
 	}
-	if got, want := monitorChartHeight(70, 9), 3; got != want {
+	if got, want := monitorChartHeight(7), 3; got != want {
 		t.Fatalf("expected minimum chart height %d for tight pane, got %d", want, got)
 	}
 }

--- a/app/model.go
+++ b/app/model.go
@@ -61,6 +61,24 @@ const (
 	workspaceContextMonitor
 )
 
+// Workspace layout constants.
+const (
+	minWorkspaceW    = 100 // terminal width below which workspace uses compact mode
+	minWorkspaceH    = 12  // content height below which workspace uses compact mode
+	minTopH          = 3   // minimum top pane height to show split layout
+	minActivityH     = 4   // minimum usable activity pane height
+	defaultActivityH = 8   // activity pane height on normal terminals
+	compactActivityH = 5   // activity pane height on shorter terminals
+	navigatorPct     = 58  // navigator width as percentage of terminal width
+	minNavigatorW    = 40  // minimum navigator pane width
+	minContextW      = 24  // minimum context pane width
+
+	// Top pane caps per view.
+	containerTopPaneCap = 9 // 5 data rows + widget/table framing
+	monitorFramingLines = 4 // widget header + summary + table header + blank
+	maxMonitorRows      = 5 // max visible monitor rows in workspace top pane
+)
+
 type workspaceContext struct {
 	kind              workspaceContextKind
 	title             string
@@ -275,12 +293,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case appui.MonitorStatsMsg:
+		prevRows := m.monitor.RowCount()
 		cmd := m.monitor.UpdateStats(msg.CID, msg.Stats, msg.StatsCh)
+		if m.workspaceEnabled() && m.monitor.RowCount() != prevRows {
+			m.resizeContentModels()
+		}
 		m.refreshPinnedWorkspaceContext()
 		return m, tea.Batch(cmd, m.workspaceMonitorActivityCmd(msg.CID))
 
 	case appui.MonitorErrorMsg:
+		prevRows := m.monitor.RowCount()
 		m.monitor.RemoveContainer(msg.CID)
+		if m.workspaceEnabled() && m.monitor.RowCount() != prevRows {
+			m.resizeContentModels()
+		}
 		m.refreshPinnedWorkspaceContext()
 		return m, m.workspaceMonitorActivityCmd(msg.CID)
 
@@ -1469,59 +1495,51 @@ func (m model) workspaceEnabled() bool {
 }
 
 func (m model) workspaceCompactMode() bool {
-	return m.width < 100 || m.contentHeight() < 12
+	return m.width < minWorkspaceW || m.contentHeight() < minWorkspaceH
 }
 
 func (m model) workspaceLayout() (navigatorW, contextW, topH, activityH int) {
-	contentH := m.contentHeight()
-	usableH := contentH - 1 // reserve one line for workspace tabs
+	usableH := m.contentHeight() - 1 // reserve one line for workspace tabs
 	if usableH < 1 {
 		return m.width, 0, 0, 0
 	}
-	if m.workspaceCompactMode() {
-		return m.width, 0, usableH, 0
-	}
-	if usableH < 7 {
+	if m.workspaceCompactMode() || usableH < minActivityH+minTopH {
 		return m.width, 0, usableH, 0
 	}
 
-	activityH = 8
-	if usableH < 18 {
-		activityH = 5
+	// Base activity pane height, then derive topH.
+	activityH = defaultActivityH
+	if usableH < defaultActivityH+containerTopPaneCap+1 {
+		activityH = compactActivityH
 	}
 	topH = usableH - activityH
-	if topH < 3 {
-		topH = usableH
-		activityH = 0
+	if topH < minTopH {
+		return m.width, 0, usableH, 0
 	}
 
-	// In workspace mode, favor the activity pane in the container view.
-	// ContainersModel currently needs 9 lines to show at most 5 data rows:
-	// 5 rows + widget/table framing.
-	if m.view == Main && topH > 9 {
-		topH = 9
-		activityH = usableH - topH
-	}
-	if m.view == Monitor && topH > 10 {
-		topH = 10
-		activityH = usableH - topH
-	}
+	// Per-view cap: shrink top pane, give remainder to activity.
+	topH = min(topH, m.topPaneCap())
+	activityH = usableH - topH
 
-	navigatorW = m.width * 58 / 100
-	if navigatorW < 40 {
-		navigatorW = 40
+	// Horizontal split for navigator / context panes.
+	navigatorW = max(1, min(m.width*navigatorPct/100, m.width-minContextW))
+	if navigatorW < minNavigatorW && m.width >= minNavigatorW+minContextW {
+		navigatorW = minNavigatorW
 	}
-	if navigatorW > m.width-24 {
-		navigatorW = m.width - 24
+	contextW = max(1, m.width-navigatorW)
+	return
+}
+
+// topPaneCap returns the maximum top pane height for the current view.
+func (m model) topPaneCap() int {
+	switch m.view {
+	case Main:
+		return containerTopPaneCap
+	case Monitor:
+		return monitorFramingLines + max(1, min(m.monitor.RowCount(), maxMonitorRows))
+	default:
+		return int(^uint(0) >> 1) // max int — no cap
 	}
-	if navigatorW < 1 {
-		navigatorW = m.width
-	}
-	contextW = m.width - navigatorW
-	if contextW < 1 {
-		contextW = 1
-	}
-	return navigatorW, contextW, topH, activityH
 }
 
 func (m *model) resizeContentModels() {

--- a/app/model_test.go
+++ b/app/model_test.go
@@ -451,8 +451,8 @@ func TestModel_WorkspaceMonitorViewKeepsExtraF7SpaceForActivity(t *testing.T) {
 	m.resizeContentModels()
 
 	_, _, topBefore, activityBefore := m.workspaceLayout()
-	if topBefore != 10 {
-		t.Fatalf("expected monitor workspace top pane height 10, got %d", topBefore)
+	if topBefore != 5 {
+		t.Fatalf("expected empty monitor workspace top pane height 5, got %d", topBefore)
 	}
 
 	result, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyF7})
@@ -464,6 +464,21 @@ func TestModel_WorkspaceMonitorViewKeepsExtraF7SpaceForActivity(t *testing.T) {
 	}
 	if activityAfter <= activityBefore {
 		t.Fatalf("expected extra height after F7 to go to activity pane, got %d -> %d", activityBefore, activityAfter)
+	}
+}
+
+func TestModel_WorkspaceMonitorViewShrinksToVisibleRowCount(t *testing.T) {
+	m := newWorkspaceTestModel()
+	m.view = Monitor
+	m.resizeContentModels()
+
+	ch := make(chan *docker.Stats)
+	m.monitor.UpdateStats("aaa", &docker.Stats{CID: "aaa", CPUPercentage: 10, MemoryPercentage: 20}, ch)
+	m.monitor.UpdateStats("bbb", &docker.Stats{CID: "bbb", CPUPercentage: 30, MemoryPercentage: 40}, ch)
+
+	_, _, topH, _ := m.workspaceLayout()
+	if topH != 6 {
+		t.Fatalf("expected monitor workspace top pane height 6 for two rows, got %d", topH)
 	}
 }
 

--- a/app/render_test.go
+++ b/app/render_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -239,5 +240,70 @@ func TestRenderWorkspaceScreen_ShortTerminalShowsActivityPaneInCompactMode(t *te
 	}
 	if strings.Contains(v, "Context ·") {
 		t.Fatal("did not expect context pane to render in short compact mode")
+	}
+}
+
+func TestRenderWorkspaceScreen_MonitorViewDoesNotGrowPastTopPane(t *testing.T) {
+	appui.InitStyles()
+	m := NewModel(Config{WorkspaceMode: true})
+	m.width = 120
+	m.height = 30
+	m.daemon = &mocks.DockerDaemonMock{}
+	m.ready = true
+	m.view = Monitor
+	m.header = appui.NewHeaderModel(m.daemon, m.width)
+	m.resizeContentModels()
+
+	_, _, topH, activityH := m.workspaceLayout()
+	if topH != 5 {
+		t.Fatalf("expected empty monitor top pane height 5, got %d", topH)
+	}
+	if activityH <= 0 {
+		t.Fatalf("expected positive activity height, got %d", activityH)
+	}
+
+	screen := m.renderMainScreen()
+	if got := len(strings.Split(screen, "\n")); got != m.height {
+		t.Fatalf("expected rendered screen height %d, got %d", m.height, got)
+	}
+
+	body := m.renderWorkspaceBody()
+	bodyLines := strings.Split(body, "\n")
+	if len(bodyLines) != m.contentHeight() {
+		t.Fatalf("expected workspace body to fill %d lines, got %d", m.contentHeight(), len(bodyLines))
+	}
+}
+
+func TestRenderWorkspaceScreen_MonitorFooterVisibleAfterStatsArrive(t *testing.T) {
+	appui.InitStyles()
+	m := NewModel(Config{WorkspaceMode: true})
+	m.width = 120
+	m.height = 30
+	m.daemon = &mocks.DockerDaemonMock{}
+	m.ready = true
+	m.view = Monitor
+	m.header = appui.NewHeaderModel(m.daemon, m.width)
+	m.resizeContentModels()
+
+	// Simulate stats arriving for several containers so RowCount changes.
+	ch := make(chan *docker.Stats)
+	for i := 0; i < 5; i++ {
+		cid := fmt.Sprintf("cid%02d", i)
+		msg := appui.MonitorStatsMsg{
+			CID:     cid,
+			Stats:   &docker.Stats{CID: cid, CPUPercentage: float64(i * 10)},
+			StatsCh: ch,
+		}
+		updated, _ := m.Update(msg)
+		m = updated.(model)
+	}
+
+	if m.monitor.RowCount() != 5 {
+		t.Fatalf("expected 5 monitor rows, got %d", m.monitor.RowCount())
+	}
+
+	screen := m.renderMainScreen()
+	if got := len(strings.Split(screen, "\n")); got != m.height {
+		t.Fatalf("expected rendered screen height %d, got %d", m.height, got)
 	}
 }

--- a/appui/monitor_model.go
+++ b/appui/monitor_model.go
@@ -91,7 +91,7 @@ func (m *MonitorModel) SetDaemon(d docker.ContainerDaemon) {
 func (m *MonitorModel) SetSize(w, h int) {
 	m.width = w
 	m.height = h
-	m.table.SetSize(w, maxInt(h-2, 1)) // -2 for header + summary
+	m.table.SetSize(w, maxInt(h-WidgetHeaderLines-1, 1)) // header + summary line
 }
 
 // Active returns whether monitoring is active.
@@ -223,6 +223,10 @@ func (m MonitorModel) SeriesFor(cid string) MonitorSeries {
 
 func (m MonitorModel) StatsByID(cid string) *docker.Stats {
 	return m.stats[cid]
+}
+
+func (m MonitorModel) RowCount() int {
+	return m.table.RowCount()
 }
 
 // Update handles key events.
@@ -434,19 +438,24 @@ func monitorRowColumns(s *docker.Stats) []string {
 func (m MonitorModel) renderTableView() string {
 	view := m.table.View()
 	row := m.table.SelectedRow()
-	if row == nil {
-		return view
+	if row != nil {
+		mr, ok := row.(monitorRow)
+		if ok {
+			lines := strings.Split(view, "\n")
+			selectedLine := m.table.Cursor() + 1
+			if selectedLine > 0 && selectedLine < len(lines) {
+				lines[selectedLine] = m.renderSelectedRow(lines[selectedLine], mr)
+			}
+			view = strings.Join(lines, "\n")
+		}
 	}
-	mr, ok := row.(monitorRow)
-	if !ok {
+	if m.width <= 0 {
 		return view
 	}
 	lines := strings.Split(view, "\n")
-	selectedLine := m.table.Cursor() + 1
-	if selectedLine <= 0 || selectedLine >= len(lines) {
-		return view
+	for i := range lines {
+		lines[i] = ansi.Truncate(lines[i], m.width, "")
 	}
-	lines[selectedLine] = m.renderSelectedRow(lines[selectedLine], mr)
 	return strings.Join(lines, "\n")
 }
 

--- a/appui/monitor_model_test.go
+++ b/appui/monitor_model_test.go
@@ -229,6 +229,34 @@ func TestMonitor_ViewUsesFullAllocatedHeight(t *testing.T) {
 	}
 }
 
+func TestMonitor_ViewTruncatesRowsToPaneWidth(t *testing.T) {
+	stats := map[string]*docker.Stats{
+		"aaa": {
+			CID:              "aaa",
+			CPUPercentage:    82.1,
+			Memory:           512 * 1024 * 1024,
+			MemoryLimit:      2 * 1024 * 1024 * 1024,
+			MemoryPercentage: 33.0,
+			NetworkRx:        120 * 1024 * 1024,
+			NetworkTx:        8 * 1024 * 1024,
+			BlockRead:        480 * 1024 * 1024,
+			BlockWrite:       32 * 1024 * 1024,
+			Command:          "worker",
+		},
+	}
+	m := NewMonitorModel()
+	m.SetSize(72, 8)
+	m.stats = stats
+	m.refreshTable()
+
+	view := m.View()
+	for _, line := range strings.Split(view, "\n") {
+		if got := ansi.StringWidth(line); got > 72 {
+			t.Fatalf("expected rendered monitor line width <= %d, got %d in %q", 72, got, ansi.Strip(line))
+		}
+	}
+}
+
 func TestMonitor_ViewMarksSelectedRowWithArrow(t *testing.T) {
 	stats := map[string]*docker.Stats{
 		"aaa": {CID: "aaa", CPUPercentage: 12.5, MemoryPercentage: 45.0, Command: "api"},

--- a/appui/ui.go
+++ b/appui/ui.go
@@ -12,6 +12,8 @@ const (
 	MainScreenHeaderSize = 3
 	//MainScreenFooterLength is the number of lines the footer of the main screen uses
 	MainScreenFooterLength = 1
+	//WidgetHeaderLines is the number of lines RenderWidgetHeader produces
+	WidgetHeaderLines = 1
 	//DefaultColumnSpacing defines the minimum space between columns
 	DefaultColumnSpacing = 1
 	//IDColumnWidth defines a fixed width for ID columns

--- a/appui/workspace/activity_model.go
+++ b/appui/workspace/activity_model.go
@@ -38,7 +38,7 @@ func NewActivityModel() ActivityModel {
 func (m *ActivityModel) SetSize(w, h int) {
 	m.width = w
 	m.height = h
-	bodyHeight := h - 2
+	bodyHeight := h - appui.WidgetHeaderLines - 1 // header + status line
 	if bodyHeight < 1 {
 		bodyHeight = 1
 	}
@@ -98,7 +98,7 @@ func (m ActivityModel) Height() int {
 
 // BodyHeight returns the usable content height below the header and status line.
 func (m ActivityModel) BodyHeight() int {
-	bodyHeight := m.height - 2
+	bodyHeight := m.height - appui.WidgetHeaderLines - 1
 	if bodyHeight < 1 {
 		return 1
 	}
@@ -168,6 +168,9 @@ func (m ActivityModel) View() string {
 	bodyContent := m.viewport.View()
 	if m.isStaticMonitorDetails() {
 		bodyContent = m.content
+		if lines := strings.Split(bodyContent, "\n"); len(lines) > bodyHeight {
+			bodyContent = strings.Join(lines[:bodyHeight], "\n")
+		}
 	}
 	body := lipgloss.NewStyle().
 		Width(m.width).

--- a/appui/workspace/activity_model_test.go
+++ b/appui/workspace/activity_model_test.go
@@ -26,6 +26,24 @@ func TestActivityModel_MonitorDetailsHeaderHidesFollowAndCounts(t *testing.T) {
 	}
 }
 
+func TestActivityModel_MonitorDetailsViewTruncatesToHeight(t *testing.T) {
+	m := NewActivityModel()
+	m.SetSize(80, 12)
+
+	// Create content taller than the body (12 - 2 = 10 lines for body).
+	var lines []string
+	for i := 0; i < 30; i++ {
+		lines = append(lines, "line")
+	}
+	m.SetContent("Monitor Details: redis", "Live stats", strings.Join(lines, "\n"))
+
+	view := m.View()
+	got := len(strings.Split(view, "\n"))
+	if got != m.Height() {
+		t.Fatalf("expected view to produce exactly %d lines, got %d", m.Height(), got)
+	}
+}
+
 func TestActivityModel_MonitorDetailsIgnoreScrollKeys(t *testing.T) {
 	m := NewActivityModel()
 	m.SetSize(80, 12)


### PR DESCRIPTION

- Fix missing footer bar in workspace Monitor view caused by activity pane overflow. ActivityModel.View() now truncates static monitor details content to fit allocated height
- Fix layout mismatch when monitor row count changes — resizeContentModels() is now called when stats arrive/depart in workspace mode
- Lay out CPU and Memory charts side-by-side instead of stacked vertically
- Extract topPaneCap() to dynamically size the monitor top pane based on actual row count
- Replace ~25 magic numbers across layout and chart code with named constants and proportional calculations