### PR TITLE
perf: fix panic and reduce CPU usage in monitor mode

### DIFF
--- a/app/messages.go
+++ b/app/messages.go
@@ -49,6 +49,8 @@ type statusMessageMsg struct {
 
 type flushRefreshMsg struct{}
 
+type flushMonitorStatsMsg struct{}
+
 // messageBarExpiredMsg triggers a re-render so the expired message clears.
 type messageBarExpiredMsg struct{}
 

--- a/app/model.go
+++ b/app/model.go
@@ -160,6 +160,9 @@ type model struct {
 	pendingRefresh map[docker.SourceType]bool
 	refreshTimer   bool
 
+	// Monitor stats workspace throttling
+	monitorStatsTimer bool
+
 	// Loading animation
 	loadingFrame int
 	loadingFwd   bool
@@ -293,13 +296,23 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case appui.MonitorStatsMsg:
-		prevRows := m.monitor.RowCount()
+		prevCount := m.monitor.StatsCount()
 		cmd := m.monitor.UpdateStats(msg.CID, msg.Stats, msg.StatsCh)
-		if m.workspaceEnabled() && m.monitor.RowCount() != prevRows {
-			m.resizeContentModels()
+		newContainer := m.monitor.StatsCount() != prevCount
+		if newContainer {
+			m.monitor.FlushTable()
+			if m.workspaceEnabled() {
+				m.resizeContentModels()
+			}
 		}
-		m.refreshPinnedWorkspaceContext()
-		return m, tea.Batch(cmd, m.workspaceMonitorActivityCmd(msg.CID))
+		cmds := []tea.Cmd{cmd}
+		if !m.monitorStatsTimer {
+			m.monitorStatsTimer = true
+			cmds = append(cmds, tea.Tick(500*time.Millisecond, func(time.Time) tea.Msg {
+				return flushMonitorStatsMsg{}
+			}))
+		}
+		return m, tea.Batch(cmds...)
 
 	case appui.MonitorErrorMsg:
 		prevRows := m.monitor.RowCount()
@@ -451,6 +464,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.pendingRefresh = make(map[docker.SourceType]bool)
 		return m, tea.Batch(cmds...)
+
+	case flushMonitorStatsMsg:
+		m.monitorStatsTimer = false
+		m.monitor.FlushTable()
+		m.refreshPinnedWorkspaceContext()
+		return m, m.workspaceMonitorActivityCmdThrottled()
 
 	case operationSuccessMsg:
 		m.messageBar.SetMessage(msg.message, 3*time.Second)
@@ -3004,6 +3023,19 @@ func (m model) loadViewData(v viewMode) tea.Cmd {
 		return loadComposeServicesCmd(m.daemon, m.selectedProject)
 	}
 	return nil
+}
+
+func (m model) workspaceMonitorActivityCmdThrottled() tea.Cmd {
+	if !m.workspaceEnabled() || m.daemon == nil {
+		return nil
+	}
+	if m.pinnedContext != nil {
+		if m.pinnedContext.kind == workspaceContextMonitor {
+			return loadWorkspaceActivityCmd(m.daemon, *m.pinnedContext, m.workspaceLogs.Width(), m.workspaceLogs.BodyHeight())
+		}
+		return nil
+	}
+	return m.workspaceSelectionActivityCmd()
 }
 
 func (m model) workspaceMonitorActivityCmd(cid string) tea.Cmd {

--- a/app/model_test.go
+++ b/app/model_test.go
@@ -475,6 +475,7 @@ func TestModel_WorkspaceMonitorViewShrinksToVisibleRowCount(t *testing.T) {
 	ch := make(chan *docker.Stats)
 	m.monitor.UpdateStats("aaa", &docker.Stats{CID: "aaa", CPUPercentage: 10, MemoryPercentage: 20}, ch)
 	m.monitor.UpdateStats("bbb", &docker.Stats{CID: "bbb", CPUPercentage: 30, MemoryPercentage: 40}, ch)
+	m.monitor.FlushTable()
 
 	_, _, topH, _ := m.workspaceLayout()
 	if topH != 6 {

--- a/appui/monitor_model.go
+++ b/appui/monitor_model.go
@@ -149,14 +149,19 @@ func (m *MonitorModel) startContainerStats(c *docker.Container) (<-chan *docker.
 	return ch, cancel, nil
 }
 
-// UpdateStats updates stats for a container and refreshes the table.
+// UpdateStats stores stats and records history without rebuilding the table.
+// Call FlushTable to apply accumulated updates to the table.
 // Returns a command to continue listening on the same channel.
 func (m *MonitorModel) UpdateStats(cid string, stats *docker.Stats, ch <-chan *docker.Stats) tea.Cmd {
 	m.stats[cid] = stats
 	m.recordHistory(cid, stats)
-	m.refreshTable()
 	// Re-subscribe to the same channel
 	return listenContainerStats(cid, ch)
+}
+
+// FlushTable rebuilds the table rows from the current stats.
+func (m *MonitorModel) FlushTable() {
+	m.refreshTable()
 }
 
 // RemoveContainer removes a container from monitoring.
@@ -227,6 +232,11 @@ func (m MonitorModel) StatsByID(cid string) *docker.Stats {
 
 func (m MonitorModel) RowCount() int {
 	return m.table.RowCount()
+}
+
+// StatsCount returns the number of containers with stored stats.
+func (m MonitorModel) StatsCount() int {
+	return len(m.stats)
 }
 
 // Update handles key events.

--- a/appui/monitor_model_test.go
+++ b/appui/monitor_model_test.go
@@ -312,6 +312,7 @@ func TestMonitor_SelectedSeriesTracksRecentSamples(t *testing.T) {
 	} {
 		m.UpdateStats("abc", &docker.Stats{CID: "abc", CPUPercentage: sample.cpu, MemoryPercentage: sample.mem}, ch)
 	}
+	m.FlushTable()
 
 	series := m.SelectedSeries()
 	if got, want := len(series.CPU), 3; got != want {

--- a/docker/stats.go
+++ b/docker/stats.go
@@ -37,12 +37,12 @@ func (s *StatsChannel) Start(ctx context.Context) <-chan *Stats {
 		responseBody := containerStats.Body
 		defer responseBody.Close()
 
-		var statsJSON container.StatsResponse
 		dec := jsoniter.NewDecoder(responseBody)
 	loop:
 		for {
 			select {
 			default:
+				var statsJSON container.StatsResponse
 				if err := dec.Decode(&statsJSON); err != nil {
 					if err == io.EOF {
 						nonBlockingSend(stats, &Stats{


### PR DESCRIPTION

Fixes a concurrent map access panic in the stats streaming path
where the decoder and renderer could read and write the same
MemoryStats.Stats map simultaneously.

Reduces CPU usage in monitor and workspace mode by throttling
stats-driven refreshes. Previously every stats message triggered
a table rebuild, workspace context regeneration, and activity
pane chart rendering, once per container per second. These are
now batched behind a 500ms debounce timer.